### PR TITLE
docs: 开发流程改为功能分支 + 命名规则

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,18 @@
 
 ## 开发流程
 
-- **开发分支 `dev`**：日常改动直接 push 到 `dev`（无保护，快速迭代）；CI 会在每次 push 自动跑冒烟。
+- **功能分支（日常开发）**：每次改动都**从 `dev` 新建分支**，开发完成后 **PR 合并回 `dev`**（CI 必须绿）。命名规则（`描述` 用 kebab-case，如 `feat/mcp-tools`）：
+
+  | 前缀 | 用途 |
+  |------|------|
+  | `feat/` | 新功能 |
+  | `fix/` | 修复 |
+  | `docs/` | 文档 |
+  | `refactor/` | 重构 |
+  | `chore/` | 杂项（CI / 依赖 / 构建） |
+
+  示例：`git checkout -b feat/video-understanding dev`
+- **`dev`（集成分支，无保护）**：功能分支合并到这里；保持可跑，CI 每次 push 自动冒烟。
 - **发布分支 `main`（受保护）**：`main` 只接受 PR 合入 —— PR 必须 **Smoke test** 通过 + 1 个 approval；直接 push 会被拒（admin 也不例外）。
 - **发版**：`dev` 稳定后开 PR `dev → main`，合并后打 `git tag vX.Y.Z && git push origin vX.Y.Z` —— [Release workflow](.github/workflows/release.yml) 会自动创建 GitHub Release。
 
@@ -13,7 +24,7 @@ uv sync --no-dev --frozen   # 安装依赖（含本项目）
 uv run bilinote-mcp setup   # 配置 LLM / 转写
 ```
 
-## 冒烟测试（CI 在跑的就是这套）
+## 冒烟测试（CI）
 
 ```bash
 uv run python -c "import bilinote_mcp.server; print('import OK')"


### PR DESCRIPTION
按新工作流演示：功能分支 → PR → dev。

- 日常开发从 dev 建功能分支（`feat/`/`fix/`/`docs/`/`refactor/`/`chore/`）
- 开发完 PR 合并回 dev（CI 冒烟必须绿）