### PR TITLE
fix(logger): 延迟解析日志目录,避免日志误落 CWD/logs

### DIFF
--- a/app/utils/logger.py
+++ b/app/utils/logger.py
@@ -1,11 +1,18 @@
 import logging
 import os
 import sys
+from functools import lru_cache
 from pathlib import Path
 
-# 日志目录：落在 VIDEONOTE_DATA_DIR/logs（由 videonote_mcp.config 设置），避免依赖 CWD
-LOG_DIR = Path(os.environ.get("VIDEONOTE_DATA_DIR", ".")) / "logs"
-LOG_DIR.mkdir(parents=True, exist_ok=True)
+# 日志目录：落在 VIDEONOTE_DATA_DIR/logs（由 videonote_mcp.config 设置），避免依赖 CWD。
+# 必须延迟到首次 get_logger() 时才解析 —— 否则若本模块在 setup_environment() 之前被
+# import（如 cli.py → provider_probe → openai_client 的链路），环境变量尚未就绪，
+# LOG_DIR 会落到当前工作目录（CWD/logs），而不是数据目录。
+@lru_cache(maxsize=1)
+def _log_dir() -> Path:
+    d = Path(os.environ.get("VIDEONOTE_DATA_DIR", ".")) / "logs"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
 
 # 日志格式
 formatter = logging.Formatter(
@@ -17,17 +24,19 @@ formatter = logging.Formatter(
 console_handler = logging.StreamHandler(sys.stderr)
 console_handler.setFormatter(formatter)
 
-# 文件输出
-file_handler = logging.FileHandler(LOG_DIR / "app.log", encoding="utf-8")
-file_handler.setFormatter(formatter)
+# 文件输出：同样延迟到首次调用 get_logger() 时创建，此时 VIDEONOTE_DATA_DIR 已就绪
+_file_handler = None
 
-# 获取日志器
 
 def get_logger(name: str) -> logging.Logger:
+    global _file_handler
     logger = logging.getLogger(name)
     if not logger.handlers:
         logger.setLevel(logging.INFO)
         logger.addHandler(console_handler)
-        logger.addHandler(file_handler)
+        if _file_handler is None:
+            _file_handler = logging.FileHandler(_log_dir() / "app.log", encoding="utf-8")
+            _file_handler.setFormatter(formatter)
+        logger.addHandler(_file_handler)
         logger.propagate = False
     return logger

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 按关键节点记录项目变更（日期 + 做了什么 + 文档改了什么）。
 
+## 维护（2026-08-06 · 发布 v0.1.4）
+
+v0.1.3 → v0.1.4 的主要变更（稳定安装：`uvx --from git+https://github.com/HuangYincan/VideoNote-MCP@v0.1.4 videonote`）：
+
+- **修复日志误落 CWD/logs**：`app/utils/logger.py` 日志目录改为首次 `get_logger()` 时延迟解析（不再在 import 时锁定），`videonote_mcp/cli.py` 的 `setup_environment()` 提前到 `provider_probe` import 之前——日志从 `~/logs`（CWD）回到数据目录 `~/.local/share/videonote-mcp/logs/`。
+
 ## 维护（2026-08-04 · 发布 v0.1.3）
 
 v0.1.2 → v0.1.3 的主要变更（稳定安装：`uvx --from git+https://github.com/HuangYincan/VideoNote-MCP@v0.1.3 videonote`）：

--- a/videonote_mcp/cli.py
+++ b/videonote_mcp/cli.py
@@ -15,6 +15,12 @@ import sys
 from pathlib import Path
 
 from videonote_mcp.config import get_app_config, remove_app_config, set_app_config, setup_environment
+
+# 提前初始化运行时环境（数据目录、DB、输出目录）——必须在 import provider_probe / app.*
+# 之前执行。provider_probe 会连累 app.utils.logger（其日志目录依赖 VIDEONOTE_DATA_DIR），
+# 若 setup 在其后，LOG_DIR 会落到 CWD/logs。
+DATA_DIR = setup_environment()
+
 from videonote_mcp.provider_probe import probe_chat, probe_models
 
 # 轻量 CLI 不该被 import 时的裸 print 污染 stdout，先进程级重定向到 stderr
@@ -27,8 +33,6 @@ def _print_to_stderr(*args, **kwargs):
 
 
 builtins.print = _print_to_stderr
-
-DATA_DIR = setup_environment()
 
 # 只导入 provider 相关（不触发 app.downloaders / app.transcriber 的 import 噪音）
 from app.db.init_db import init_db


### PR DESCRIPTION
## 背景

修复日志误落 CWD/logs 的 import 顺序 bug。

## 变更

- `app/utils/logger.py`:LOG_DIR 延迟到首次 get_logger() 时解析(惰性 _log_dir + _file_handler)
- `videonote_mcp/cli.py`:setup_environment() 提前到 provider_probe import 之前

## 验证

本地实测日志落到数据目录;uvx 启动端到端验证通过。见 CHANGELOG v0.1.4。