### PR TITLE
release: v0.1.4 —— 补齐版本号 bump (pyproject/uv.lock)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote-mcp"
-version = "0.1.3"
+version = "0.1.4"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：av / faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/uv.lock
+++ b/uv.lock
@@ -4389,7 +4389,7 @@ wheels = [
 
 [[package]]
 name = "videonote-mcp"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
v0.1.4 发布时漏改 pyproject.toml/uv.lock，版本号仍为 0.1.3。本 PR 补齐。
验证：uv lock 后 uv.lock 同步 0.1.4。