### PR TITLE
docs(readme): 中英 README 同步 —— intro 句补全 + setup 标为可选

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ VideoNote-Mcp 把「视频链接 → 多格式笔记」整条流水线打包成 
 
 仓库：[HuangYincan/VideoNote-MCP](https://github.com/HuangYincan/VideoNote-MCP)。
 
-本项目**既可端到端使用（一条链接 → 一篇笔记）**，**也可解耦**：流水线每一阶段（下载 / 转写 / 抽帧 / 评论 / 总结 / 导出 / 增强 / 清理）都是独立 MCP 工具，想只用某一步、或自己拼素材再总结，都能任意组合。无需启动任何后端服务。
+本项目**既可端到端使用（一条链接 → 一篇笔记）**，**也可解耦**：流水线每一阶段（下载 / 转写 / 抽帧 / 评论 / 总结 / 导出 / 增强 / 清理）都是独立 MCP 工具，想只用某一步、或只想了解视频内容，都能满足。无需启动任何后端服务。
 
 <p align="center">
   <a href="https://github.com/HuangYincan/VideoNote-MCP"><img src="https://img.shields.io/github/stars/HuangYincan/VideoNote-MCP?logo=github" alt="GitHub stars"></a>
@@ -49,7 +49,7 @@ claude plugin marketplace add HuangYincan/VideoNote-MCP
 claude plugin install videonote@videonote
 
 # 2) 配置 LLM key + 语音转写引擎（key 不进对话）
-videonote setup
+# videonote setup (可选，如需其它多模态模型兜底)
 
 # 3) 重启会话，对 agent 说「帮我给这个视频做笔记」+ 链接
 ```

--- a/README_EN.md
+++ b/README_EN.md
@@ -27,7 +27,7 @@ VideoNote-Mcp packages the whole "video link → multi-format notes" pipeline in
 
 Repository: [HuangYincan/VideoNote-MCP](https://github.com/HuangYincan/VideoNote-MCP).
 
-This project **works end-to-end (one link → one note)** and is **also decoupled**: every pipeline stage (download / transcribe / frames / comments / summarize / export / enhance / cleanup) is an independent MCP tool, so you can use just one step or assemble your own material and summarize it in any combination. No backend required.
+This project **works end-to-end (one link → one note)** and is **also decoupled**: every pipeline stage (download / transcribe / frames / comments / summarize / export / enhance / cleanup) is an independent MCP tool, so whether you just want to use one step or simply get a sense of the video's content, either need is covered. No backend required.
 
 <p align="center">
   <a href="https://github.com/HuangYincan/VideoNote-MCP"><img src="https://img.shields.io/github/stars/HuangYincan/VideoNote-MCP?logo=github" alt="GitHub stars"></a>
@@ -48,7 +48,7 @@ claude plugin marketplace add HuangYincan/VideoNote-MCP
 claude plugin install videonote@videonote
 
 # 2) Configure LLM key + transcription engine (keys never enter the conversation)
-videonote setup
+# videonote setup (optional, if you need other multimodal models as a fallback)
 
 # 3) Restart your session, tell the agent "make notes for this video" + link
 ```


### PR DESCRIPTION
## 改动

同步用户对中文 README 的改动到英文版，并补全残缺部分：

- **README.md**：intro 句残缺结尾「或只想了解视频内容，都。」补全为「都能满足。」；快速开始把 `videonote setup` 标为可选（用户原改动）
- **README_EN.md**：intro 句镜像新意；`videonote setup` 同步注释为可选

未改动 docs/04、CHANGELOG、SKILL、pyproject.toml。