### PR TITLE
feat: setup 整合进 /plugin + 修复插件 MCP server 不注册

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,26 +12,7 @@
       "source": "./",
       "description": "生成视频笔记的 Skill 与 MCP server（下载→转写→LLM→Markdown）",
       "displayName": "VideoNote",
-      "skills": ["./skills/videonote"],
-      "mcpServers": {
-        "videonote": {
-          "command": "uvx",
-          "args": [
-            "--from",
-            "git+https://github.com/HuangYincan/VideoNote-MCP",
-            "videonote"
-          ],
-          "env": {
-            "VIDEONOTE_DEFAULT_STYLE": "${user_config.default_style}",
-            "VIDEONOTE_DEFAULT_SCREENSHOT": "${user_config.default_screenshot}",
-            "VIDEONOTE_VIDEO_UNDERSTANDING": "${user_config.video_understanding}",
-            "VIDEONOTE_INCLUDE_COMMENTS": "${user_config.include_comments}",
-            "VIDEONOTE_NOTES_DIR": "${user_config.notes_dir}",
-            "TRANSCRIBER_TYPE": "${user_config.transcriber_type}",
-            "WHISPER_MODEL_SIZE": "${user_config.whisper_model_size}"
-          }
-        }
-      }
+      "skills": ["./skills/videonote"]
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,16 @@
             "--from",
             "git+https://github.com/HuangYincan/VideoNote-MCP",
             "videonote"
-          ]
+          ],
+          "env": {
+            "VIDEONOTE_DEFAULT_STYLE": "${user_config.default_style}",
+            "VIDEONOTE_DEFAULT_SCREENSHOT": "${user_config.default_screenshot}",
+            "VIDEONOTE_VIDEO_UNDERSTANDING": "${user_config.video_understanding}",
+            "VIDEONOTE_INCLUDE_COMMENTS": "${user_config.include_comments}",
+            "VIDEONOTE_NOTES_DIR": "${user_config.notes_dir}",
+            "TRANSCRIBER_TYPE": "${user_config.transcriber_type}",
+            "WHISPER_MODEL_SIZE": "${user_config.whisper_model_size}"
+          }
         }
       }
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,6 +6,25 @@
     "url": "https://github.com/HuangYincan"
   },
   "commands": ["./commands/"],
+  "mcpServers": {
+    "videonote": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/HuangYincan/VideoNote-MCP",
+        "videonote"
+      ],
+      "env": {
+        "VIDEONOTE_DEFAULT_STYLE": "${user_config.default_style}",
+        "VIDEONOTE_DEFAULT_SCREENSHOT": "${user_config.default_screenshot}",
+        "VIDEONOTE_VIDEO_UNDERSTANDING": "${user_config.video_understanding}",
+        "VIDEONOTE_INCLUDE_COMMENTS": "${user_config.include_comments}",
+        "VIDEONOTE_NOTES_DIR": "${user_config.notes_dir}",
+        "TRANSCRIBER_TYPE": "${user_config.transcriber_type}",
+        "WHISPER_MODEL_SIZE": "${user_config.whisper_model_size}"
+      }
+    }
+  },
   "userConfig": {
     "default_style": {
       "type": "string",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,5 +4,49 @@
   "author": {
     "name": "HuangYincan",
     "url": "https://github.com/HuangYincan"
+  },
+  "commands": ["./commands/"],
+  "userConfig": {
+    "default_style": {
+      "type": "string",
+      "title": "笔记风格默认",
+      "description": "minimal 精简 / detailed 详细 / academic 学术 / tutorial 教程 / xiaohongshu 小红书 / life_journal 生活向 / task_oriented 任务导向 / business 商业 / meeting_minutes 会议纪要",
+      "default": "detailed"
+    },
+    "default_screenshot": {
+      "type": "boolean",
+      "title": "笔记默认插图",
+      "description": "生成笔记时默认插入视频截图",
+      "default": false
+    },
+    "video_understanding": {
+      "type": "boolean",
+      "title": "视频理解默认",
+      "description": "默认把画面抽帧发给多模态 LLM（需多模态模型）",
+      "default": false
+    },
+    "include_comments": {
+      "type": "boolean",
+      "title": "弹幕+评论整合默认",
+      "description": "默认把 B 站弹幕+热门评论整合进笔记（需 SESSDATA）",
+      "default": false
+    },
+    "notes_dir": {
+      "type": "directory",
+      "title": "笔记默认位置",
+      "description": "便携笔记输出目录"
+    },
+    "transcriber_type": {
+      "type": "string",
+      "title": "语音转写引擎",
+      "description": "fast-whisper 本地 / groq / bcut / kuaishou / mlx-whisper",
+      "default": "fast-whisper"
+    },
+    "whisper_model_size": {
+      "type": "string",
+      "title": "Whisper 模型尺寸",
+      "description": "tiny / base / small / medium / large-v3 / large-v3-turbo",
+      "default": "tiny"
+    }
   }
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,25 +16,25 @@
     "default_screenshot": {
       "type": "boolean",
       "title": "笔记默认插图",
-      "description": "点开关切换。true=生成笔记时默认插入视频截图",
+      "description": "输入 true 或 false。true=生成笔记时默认插入视频截图",
       "default": false
     },
     "video_understanding": {
       "type": "boolean",
       "title": "视频理解默认",
-      "description": "点开关切换。true=默认把画面抽帧发给多模态 LLM（需多模态模型）",
+      "description": "输入 true 或 false。true=默认把画面抽帧发给多模态 LLM（需多模态模型）",
       "default": false
     },
     "include_comments": {
       "type": "boolean",
       "title": "弹幕+评论整合默认",
-      "description": "点开关切换。true=默认把 B 站弹幕+热门评论整合进笔记（需 SESSDATA）",
+      "description": "输入 true 或 false。true=默认把 B 站弹幕+热门评论整合进笔记（需 SESSDATA）",
       "default": false
     },
     "notes_dir": {
       "type": "directory",
       "title": "笔记默认位置",
-      "description": "输入绝对路径，或点右侧图标浏览选择。留空=默认 note_results/{task_id}/",
+      "description": "输入笔记输出目录的绝对路径。留空=默认 note_results/{task_id}/",
       "default": ""
     },
     "transcriber_type": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,42 +10,43 @@
     "default_style": {
       "type": "string",
       "title": "笔记风格默认",
-      "description": "minimal 精简 / detailed 详细 / academic 学术 / tutorial 教程 / xiaohongshu 小红书 / life_journal 生活向 / task_oriented 任务导向 / business 商业 / meeting_minutes 会议纪要",
+      "description": "直接输入英文 key，其一：detailed 详细 / minimal 精简 / academic 学术 / tutorial 教程 / xiaohongshu 小红书 / life_journal 生活向 / task_oriented 任务导向 / business 商业 / meeting_minutes 会议纪要",
       "default": "detailed"
     },
     "default_screenshot": {
       "type": "boolean",
       "title": "笔记默认插图",
-      "description": "生成笔记时默认插入视频截图",
+      "description": "点开关切换。true=生成笔记时默认插入视频截图",
       "default": false
     },
     "video_understanding": {
       "type": "boolean",
       "title": "视频理解默认",
-      "description": "默认把画面抽帧发给多模态 LLM（需多模态模型）",
+      "description": "点开关切换。true=默认把画面抽帧发给多模态 LLM（需多模态模型）",
       "default": false
     },
     "include_comments": {
       "type": "boolean",
       "title": "弹幕+评论整合默认",
-      "description": "默认把 B 站弹幕+热门评论整合进笔记（需 SESSDATA）",
+      "description": "点开关切换。true=默认把 B 站弹幕+热门评论整合进笔记（需 SESSDATA）",
       "default": false
     },
     "notes_dir": {
       "type": "directory",
       "title": "笔记默认位置",
-      "description": "便携笔记输出目录"
+      "description": "输入绝对路径，或点右侧图标浏览选择。留空=默认 note_results/{task_id}/",
+      "default": ""
     },
     "transcriber_type": {
       "type": "string",
       "title": "语音转写引擎",
-      "description": "fast-whisper 本地 / groq / bcut / kuaishou / mlx-whisper",
+      "description": "直接输入英文 key，其一：fast-whisper 本地（推荐，免费）/ groq 云端 / bcut 云端 / kuaishou 云端 / mlx-whisper 本地（macOS）",
       "default": "fast-whisper"
     },
     "whisper_model_size": {
       "type": "string",
       "title": "Whisper 模型尺寸",
-      "description": "tiny / base / small / medium / large-v3 / large-v3-turbo",
+      "description": "直接输入英文 key，其一：tiny / base / small / medium / large-v3 / large-v3-turbo（内存小用 tiny/base，追求精度用 medium+）",
       "default": "tiny"
     }
   }

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ claude plugin install videonote@videonote
 > 四种安装方式、配置细节、更新与安全见 [docs/04-使用手册.md](docs/04-使用手册.md)。
 > 
 
+> [!NOTE] 插件默认值怎么填（`/plugin configure` 页）
+> `/plugin install` 时及 `/plugin configure` 页里的默认值项都是**键盘输入**（不是下拉选择）：
+> - **布尔项**（笔记默认插图 / 视频理解默认 / 弹幕+评论整合默认）：**点开关切换** `true`/`false`；
+> - **目录项**（笔记默认位置）：输入绝对路径，或点右侧图标浏览选择；
+> - **字符串项**（笔记风格 / 转写引擎 / 模型尺寸）：**直接输入英文 key** ——
+>   风格：`detailed` / `minimal` / `academic` / `tutorial` / `xiaohongshu` / `life_journal` / `task_oriented` / `business` / `meeting_minutes`；
+>   转写引擎：`fast-whisper`（本地，推荐）/ `groq` / `bcut` / `kuaishou` / `mlx-whisper`；
+>   模型尺寸：`tiny` / `base` / `small` / `medium` / `large-v3` / `large-v3-turbo`。
+> 这些只是「配置文件缺项时的兜底默认」——你本地用 `videonote setup` 配置的
+> `app_config.json` / `transcriber.json` 优先级更高，只有它们没设某项时才用这里的值。
+
 ## 📚 文档
 
 安装 / 配置 / 使用 / 环境变量 / 更新 / 安全等完整说明已归档到 `docs/`（README 只保留概览）：

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ claude plugin install videonote@videonote
 > 
 
 > [!NOTE] 插件默认值怎么填（`/plugin configure` 页）
-> `/plugin install` 时及 `/plugin configure` 页里的默认值项都是**键盘输入**（不是下拉选择）：
-> - **布尔项**（笔记默认插图 / 视频理解默认 / 弹幕+评论整合默认）：**点开关切换** `true`/`false`；
-> - **目录项**（笔记默认位置）：输入绝对路径，或点右侧图标浏览选择；
+> `/plugin install` 时及 `/plugin configure` 页里的默认值项**全部手动输入**（无下拉/开关）：
+> - **布尔项**（笔记默认插图 / 视频理解默认 / 弹幕+评论整合默认）：输入 `true` 或 `false`；
+> - **目录项**（笔记默认位置）：输入笔记输出目录的**绝对路径**，留空 = 默认 `note_results/{task_id}/`；
 > - **字符串项**（笔记风格 / 转写引擎 / 模型尺寸）：**直接输入英文 key** ——
 >   风格：`detailed` / `minimal` / `academic` / `tutorial` / `xiaohongshu` / `life_journal` / `task_oriented` / `business` / `meeting_minutes`；
 >   转写引擎：`fast-whisper`（本地，推荐）/ `groq` / `bcut` / `kuaishou` / `mlx-whisper`；

--- a/README.md
+++ b/README.md
@@ -48,10 +48,15 @@ VideoNote-Mcp 把「视频链接 → 多格式笔记」整条流水线打包成 
 claude plugin marketplace add HuangYincan/VideoNote-MCP
 claude plugin install videonote@videonote
 
-# 2) 配置 LLM key + 语音转写引擎（key 不进对话）
-# videonote setup (可选，如需其它多模态模型兜底)
+# 2) 安装时 Claude Code 会逐项提示默认值（风格/转写引擎/视频理解/评论等）；
+#    装完在会话里跑配置向导收尾：
+/videonote-setup
 
-# 3) 重启会话，对 agent 说「帮我给这个视频做笔记」+ 链接
+# 3) 填 LLM key（隐藏输入，值不进对话）：在本会话输入
+#    ! videonote providers set <provider_id> --api-key 'sk-...'
+#    （B 站扫码：! videonote login bilibili；全屏向导：! videonote setup，独立终端更稳）
+
+# 4) 重启会话，对 agent 说「帮我给这个视频做笔记」+ 链接
 ```
 
 > [!TIP] 

--- a/README_EN.md
+++ b/README_EN.md
@@ -47,10 +47,17 @@ This project **works end-to-end (one link → one note)** and is **also decouple
 claude plugin marketplace add HuangYincan/VideoNote-MCP
 claude plugin install videonote@videonote
 
-# 2) Configure LLM key + transcription engine (keys never enter the conversation)
-# videonote setup (optional, if you need other multimodal models as a fallback)
+# 2) Claude Code prompts for defaults during install (style / transcriber /
+#    video-understanding / comments etc.); then run the guided config command:
+/videonote-setup
 
-# 3) Restart your session, tell the agent "make notes for this video" + link
+# 3) Fill in your LLM key (hidden input, never enters the conversation) — type
+#    in this session:
+#    ! videonote providers set <provider_id> --api-key 'sk-...'
+#    (Bilibili QR login: ! videonote login bilibili; full wizard:
+#    ! videonote setup — better in a separate terminal)
+
+# 4) Restart your session, tell the agent "make notes for this video" + link
 ```
 
 > All four install methods, configuration details, updating and security are in [docs/04-使用手册.md](docs/04-使用手册.md).

--- a/README_EN.md
+++ b/README_EN.md
@@ -62,6 +62,19 @@ claude plugin install videonote@videonote
 
 > All four install methods, configuration details, updating and security are in [docs/04-使用手册.md](docs/04-使用手册.md).
 
+> [!NOTE] How to fill in the plugin defaults (`/plugin configure` page)
+> The default-value fields shown during `/plugin install` and on the `/plugin configure`
+> page are **typed input** (not dropdowns):
+> - **Boolean fields** (Default screenshots / Video understanding / Comments): **toggle** them `true`/`false`;
+> - **Directory field** (Default notes location): type an absolute path or browse;
+> - **String fields** (Style / Transcriber / Model size): **type the English key directly** —
+>   style: `detailed` / `minimal` / `academic` / `tutorial` / `xiaohongshu` / `life_journal` / `task_oriented` / `business` / `meeting_minutes`;
+>   transcriber: `fast-whisper` (local, recommended) / `groq` / `bcut` / `kuaishou` / `mlx-whisper`;
+>   model size: `tiny` / `base` / `small` / `medium` / `large-v3` / `large-v3-turbo`.
+> These only serve as **fallbacks when the config file lacks a value** — your local
+> `app_config.json` / `transcriber.json` (set via `videonote setup`) takes precedence.
+
+
 ## 📚 Docs
 
 Full installation / configuration / usage / env vars / updating / security docs now live in `docs/` (this README keeps just the overview):

--- a/README_EN.md
+++ b/README_EN.md
@@ -64,9 +64,9 @@ claude plugin install videonote@videonote
 
 > [!NOTE] How to fill in the plugin defaults (`/plugin configure` page)
 > The default-value fields shown during `/plugin install` and on the `/plugin configure`
-> page are **typed input** (not dropdowns):
-> - **Boolean fields** (Default screenshots / Video understanding / Comments): **toggle** them `true`/`false`;
-> - **Directory field** (Default notes location): type an absolute path or browse;
+> page are **all typed input** (no dropdowns or toggles):
+> - **Boolean fields** (Default screenshots / Video understanding / Comments): type `true` or `false`;
+> - **Directory field** (Default notes location): type an **absolute path**; leave empty for the default `note_results/{task_id}/`;
 > - **String fields** (Style / Transcriber / Model size): **type the English key directly** —
 >   style: `detailed` / `minimal` / `academic` / `tutorial` / `xiaohongshu` / `life_journal` / `task_oriented` / `business` / `meeting_minutes`;
 >   transcriber: `fast-whisper` (local, recommended) / `groq` / `bcut` / `kuaishou` / `mlx-whisper`;

--- a/commands/videonote-setup.md
+++ b/commands/videonote-setup.md
@@ -7,6 +7,20 @@ description: 配置 VideoNote-MCP：体检 / LLM 供应商 / 转写引擎 / 默�
 
 按顺序执行配置检查与引导。**已就绪的步骤直接跳过**，不要重复提问；每步做完汇报结果。
 
+## 0. 前置：确认 MCP 工具已挂载（最重要，不满足则停下）
+
+**本命令的一切配置操作都依赖 videonote 的 MCP 工具**（`mcp__videonote__*`：`health_check` / `list_providers` / `get_transcriber_config` 等）。
+先确认本会话里是否挂载了它们。**不要用 CLI / 读配置文件代替 MCP 工具**，也不要自行判断「哪份配置权威」——server 返回的 `data_dir` 才是权威（不要像 diff 数据目录那样去猜）。
+
+- **已挂载** → 继续第 1 步。
+- **未挂载** → **立即停止并引导**，不要继续后面的步骤、不要替代性跑 CLI/读文件：
+  1. 最可能原因：插件装好后**没重启会话**，插件的 MCP server 尚未加载。请用户**重启 Claude Code 会话**（或 `/reload-plugins`），再重跑本命令。
+  2. 若重启后仍没有：让用户在会话里跑 **`/mcp`**，看 `videonote` 是否 Connected、报什么错。
+  3. 常见报错：uvx 首次从 git 拉包超时（默认 30s）。用 `MCP_TIMEOUT=120000 claude` 重启会话再试。
+  4. 可选 CLI 自检（只验证 CLI 可用，**不等同 MCP 工具挂载**）——让用户在终端跑：
+     `uvx --from git+https://github.com/HuangYincan/VideoNote-MCP videonote providers list`
+- 唯一允许的只读检查：FFmpeg 是否可用（`ffmpeg -version`，`health_check` 也会查，仅作提前确认）。其余一律等 MCP 工具。
+
 ## 1. 状态体检
 
 调用 **`health_check`**，看 FFmpeg / 数据库 / 转写引擎 / whisper 模型就绪状态。

--- a/commands/videonote-setup.md
+++ b/commands/videonote-setup.md
@@ -9,13 +9,13 @@ description: 配置 VideoNote-MCP：体检 / LLM 供应商 / 转写引擎 / 默�
 
 ## 0. 前置：确认 MCP 工具已挂载（最重要，不满足则停下）
 
-**本命令的一切配置操作都依赖 videonote 的 MCP 工具**（`mcp__videonote__*`：`health_check` / `list_providers` / `get_transcriber_config` 等）。
+**本命令的一切配置操作都依赖 videonote 的 MCP 工具**（`health_check` / `list_providers` / `get_transcriber_config` 等，工具名可能带前缀如 `mcp__videonote__*` 或 `mcp__plugin_videonote_videonote__*`，**按工具名判断，不按前缀**）。
 先确认本会话里是否挂载了它们。**不要用 CLI / 读配置文件代替 MCP 工具**，也不要自行判断「哪份配置权威」——server 返回的 `data_dir` 才是权威（不要像 diff 数据目录那样去猜）。
 
 - **已挂载** → 继续第 1 步。
 - **未挂载** → **立即停止并引导**，不要继续后面的步骤、不要替代性跑 CLI/读文件：
   1. 最可能原因：插件装好后**没重启会话**，插件的 MCP server 尚未加载。请用户**重启 Claude Code 会话**（或 `/reload-plugins`），再重跑本命令。
-  2. 若重启后仍没有：让用户在会话里跑 **`/mcp`**，看 `videonote` 是否 Connected、报什么错。
+  2. 若重启后仍没有：让用户在会话里跑 **`/mcp`**，看 `videonote` 是否 Connected、报什么错。**若 `/mcp` 里根本看不到 videonote 条目**（插件虽 enabled 但 server 没注册）→ 说明插件 manifest 的 `mcpServers` 没生效，让用户重装插件再重启：`claude plugin marketplace update videonote` + `claude plugin disable videonote@videonote` + `claude plugin install videonote@videonote`。
   3. 常见报错：uvx 首次从 git 拉包超时（默认 30s）。用 `MCP_TIMEOUT=120000 claude` 重启会话再试。
   4. 可选 CLI 自检（只验证 CLI 可用，**不等同 MCP 工具挂载**）——让用户在终端跑：
      `uvx --from git+https://github.com/HuangYincan/VideoNote-MCP videonote providers list`

--- a/commands/videonote-setup.md
+++ b/commands/videonote-setup.md
@@ -1,0 +1,54 @@
+---
+name: videonote-setup
+description: 配置 VideoNote-MCP：体检 / LLM 供应商 / 转写引擎 / 默认值 / B站扫码 / 数据管理
+---
+
+# VideoNote-MCP 配置向导
+
+按顺序执行配置检查与引导。**已就绪的步骤直接跳过**，不要重复提问；每步做完汇报结果。
+
+## 1. 状态体检
+
+调用 **`health_check`**，看 FFmpeg / 数据库 / 转写引擎 / whisper 模型就绪状态。
+- FFmpeg 缺失 → 先让用户安装 FFmpeg（macOS `brew install ffmpeg`，其他平台见官方包源），装完重跑。
+
+## 2. LLM 供应商（API key）
+
+调用 **`list_providers`**，列出已配置供应商（id / 名称 / key 是否已填）。
+- 已有供应商填了 key → 跳过本步。
+- 没有已填 key 的供应商 → **让用户在本会话输入**：
+  `! videonote providers list`（看供应商 id）
+  `! videonote providers set <provider_id> --api-key '...'`（填 key）
+  - API key 为**隐藏输入**，值不经过对话；这一步必须由用户亲手在终端完成，不要试图用其它方式获取 key。
+  - 也可以用内置中转站：`! videonote setup`（全屏向导，独立终端更稳）。
+
+## 3. 语音转写引擎
+
+调用 **`get_transcriber_config`**，看当前引擎 / 模型尺寸 / 预处理 / 说话人分离。
+- 本地引擎（fast-whisper / mlx-whisper）模型未下载 → 调 **`download_transcriber_model(model_size, transcriber_type)`** 后台下载，用 `list_transcriber_models` 查进度；或让用户输 `! videonote transcriber download <size>`。
+- 要切换引擎 / 尺寸 → 调 **`set_transcriber(...)`**（fast-whisper / groq / bcut / kuaishou / mlx-whisper）。
+- 云端引擎（groq / bcut / kuaishou）无需下载模型。
+
+## 4. 默认值
+
+展示当前笔记默认值：**Read** `{health_check 返回的 data_dir}/config/app_config.json`
+（含风格 / 插图 / 视频理解 / 评论弹幕 / 导出格式 / 默认模型）。
+- 安装时 `/plugin` 的 userConfig 已收过默认值，这里主要是**展示确认**。
+- 要修改 → 让用户输 `! videonote setup`（全屏向导，独立终端更稳），或编辑该 JSON。
+
+## 5. B站扫码（可选，需要 AI 字幕 / 评论时）
+
+让用户在本会话输入：
+`! videonote login bilibili`
+- 二维码会**直接渲染进会话终端**，手机 B 站 App 扫码后自动保存 SESSDATA（进 `downloader.json`）。
+- 没配 SESSDATA 时 B 站视频仍可转写（走语音识别），只是拿不到 AI 字幕 / 弹幕评论。
+
+## 6. 数据管理（可选）
+
+- **`list_tasks`** 列全部任务（按语义标题识别）。
+- 清理单任务：**`get_task_files(task_id)`** 先看占用的文件 → **`cleanup_note(task_id, include_note?)`**。
+- 全局清理：**`cleanup_all(include_config?, include_models?)`**（默认保留配置与模型）。
+
+---
+
+配置完成后，让用户给一条视频链接验证：`generate_note` 或「AGENT 直接生成」的 `prepare_note_material`。

--- a/docs/04-使用手册.md
+++ b/docs/04-使用手册.md
@@ -38,6 +38,8 @@
 
 `/plugin install` 时 Claude Code 会**逐项提示填默认值**（笔记风格 / 转写引擎 / 模型尺寸 / 视频理解 / 评论弹幕 / 笔记位置，均非敏感）——存 Claude Code 配置，经 MCP `env` 注入 server，作为「配置文件缺项时的兜底默认」（配置文件优先，之后跑 `setup` 向导修改仍以向导为准）。
 
+**填法**（`/plugin configure` 页均为**键盘输入**，不是下拉选）：布尔项（插图/视频理解/评论）**点开关切换**；目录项（笔记位置）输入绝对路径或浏览；字符串项（风格/引擎/尺寸）**直接输入英文 key** —— 风格 `detailed`/`minimal`/`academic`/`tutorial`/`xiaohongshu`/`life_journal`/`task_oriented`/`business`/`meeting_minutes`；引擎 `fast-whisper`/`groq`/`bcut`/`kuaishou`/`mlx-whisper`；尺寸 `tiny`/`base`/`small`/`medium`/`large-v3`/`large-v3-turbo`。详情见 [README 插件默认值说明](../README.md)。
+
 装完在会话里跑 **`/videonote-setup`** 收尾：体检 → 引导填 key → 转写模型下载 → 展示默认值 → B站扫码 → 数据管理。
 
 > **凭证红线**：LLM key / SESSDATA 一律走 `!` 前缀在**本会话终端**输入（隐藏输入、值不过 agent 对话），或独立终端跑完整命令。下面的命令在本会话用 `! videonote ...` 前缀即可直接跑。

--- a/docs/04-使用手册.md
+++ b/docs/04-使用手册.md
@@ -25,7 +25,7 @@
 | 三 · uv tool install | `uv tool install --from git+https://github.com/HuangYincan/VideoNote-MCP videonote` + `claude mcp add videonote -- "$HOME/.local/bin/videonote"` | 固定版本、启动最快 |
 | 四 · 克隆 + install.sh | `git clone https://github.com/HuangYincan/VideoNote-MCP.git && cd VideoNote-MCP && ./install.sh` | 无 uv 兜底，自动弹 setup |
 
-装完重启 Claude Code 会话（或 `/reload-plugins`）生效。**方式一（marketplace）的 MCP 由插件提供**，`claude mcp list` 不会列出它（插件 server 独立注册）；在会话里直接可用工具、或跑 `/videonote-setup` 验证。方式二/四（用户级 `claude mcp add`）`claude mcp list` 会显示 `videonote`。
+装完**必须重启** Claude Code 会话（或 `/reload-plugins`）才会加载插件的 MCP server —— **重启前不要跑 `/videonote-setup`**（MCP 工具未挂载，命令会停在诊断步）。**方式一（marketplace）的 MCP 由插件提供**，`claude mcp list` 不会列出它（插件 server 独立注册）；重启后在会话里直接可用工具、或跑 `/videonote-setup` 验证。方式二/四（用户级 `claude mcp add`）`claude mcp list` 会显示 `videonote`。
 
 > [!WARNING] 混合安装注意
 > 若此前用「方式二」或旧版 `install.sh` 加过**用户级** `claude mcp add videonote`，该条目 `env` 为空，会**遮蔽插件自带 MCP server 的 env**（`/plugin` 安装时填的 userConfig 默认值不生效）。用 `claude mcp remove videonote` 移除，让插件 server 接管（命令相同 `uvx --from ...@dev videonote`、同数据目录，无功能损失）。新装请直接走**方式一**，不要再手动 `claude mcp add`。

--- a/docs/04-使用手册.md
+++ b/docs/04-使用手册.md
@@ -31,6 +31,14 @@
 
 > 所有方式共用同一数据目录（`~/.local/share/videonote-mcp/`），配好即会话内生效。
 
+### 插件方式（方式一安装，装完在 Claude Code 里配置）
+
+`/plugin install` 时 Claude Code 会**逐项提示填默认值**（笔记风格 / 转写引擎 / 模型尺寸 / 视频理解 / 评论弹幕 / 笔记位置，均非敏感）——存 Claude Code 配置，经 MCP `env` 注入 server，作为「配置文件缺项时的兜底默认」（配置文件优先，之后跑 `setup` 向导修改仍以向导为准）。
+
+装完在会话里跑 **`/videonote-setup`** 收尾：体检 → 引导填 key → 转写模型下载 → 展示默认值 → B站扫码 → 数据管理。
+
+> **凭证红线**：LLM key / SESSDATA 一律走 `!` 前缀在**本会话终端**输入（隐藏输入、值不过 agent 对话），或独立终端跑完整命令。下面的命令在本会话用 `! videonote ...` 前缀即可直接跑。
+
 ### 交互向导 `setup`（推荐，随时可反复进入修改）
 
 ```bash
@@ -44,7 +52,7 @@ videonote setup
 内置供应商（openai / deepseek / qwen / groq / ollama…）在空库时已自动预置，id 固定、base_url 正确，**只需填 key**：
 
 ```bash
-# 终端（key 不进对话）
+# 终端（key 不进对话；本会话里用 `!` 前缀，如 `! videonote providers list`）
 videonote providers list                                  # 看内置供应商，key 为空
 videonote providers set deepseek --api-key 'sk-你的key'     # 填 key（掩码回显）
 videonote providers test deepseek                          # 检测连接 + 列出可用模型
@@ -80,7 +88,7 @@ videonote transcriber download small                  # 下载 fast-whisper 模�
 videonote transcriber download small --engine mlx-whisper  # 下载 mlx-whisper（macOS）
 
 # B 站：优先用平台字幕（含 AI 字幕）跳过语音识别；AI 字幕需登录态
-videonote login bilibili     # 扫码登录，自动获取并保存 SESSDATA
+videonote login bilibili     # 扫码登录，二维码渲染进终端/会话，自动保存 SESSDATA
 videonote transcriber set groq                        # 切云端
 ```
 

--- a/docs/04-使用手册.md
+++ b/docs/04-使用手册.md
@@ -38,7 +38,7 @@
 
 `/plugin install` 时 Claude Code 会**逐项提示填默认值**（笔记风格 / 转写引擎 / 模型尺寸 / 视频理解 / 评论弹幕 / 笔记位置，均非敏感）——存 Claude Code 配置，经 MCP `env` 注入 server，作为「配置文件缺项时的兜底默认」（配置文件优先，之后跑 `setup` 向导修改仍以向导为准）。
 
-**填法**（`/plugin configure` 页均为**键盘输入**，不是下拉选）：布尔项（插图/视频理解/评论）**点开关切换**；目录项（笔记位置）输入绝对路径或浏览；字符串项（风格/引擎/尺寸）**直接输入英文 key** —— 风格 `detailed`/`minimal`/`academic`/`tutorial`/`xiaohongshu`/`life_journal`/`task_oriented`/`business`/`meeting_minutes`；引擎 `fast-whisper`/`groq`/`bcut`/`kuaishou`/`mlx-whisper`；尺寸 `tiny`/`base`/`small`/`medium`/`large-v3`/`large-v3-turbo`。详情见 [README 插件默认值说明](../README.md)。
+**填法**（`/plugin configure` 页**全部为键盘输入**，无下拉/开关）：布尔项（插图/视频理解/评论）输入 `true`/`false`；目录项（笔记位置）输入**绝对路径**，留空 = 默认；字符串项（风格/引擎/尺寸）直接输入英文 key —— 风格 `detailed`/`minimal`/`academic`/`tutorial`/`xiaohongshu`/`life_journal`/`task_oriented`/`business`/`meeting_minutes`；引擎 `fast-whisper`/`groq`/`bcut`/`kuaishou`/`mlx-whisper`；尺寸 `tiny`/`base`/`small`/`medium`/`large-v3`/`large-v3-turbo`。详情见 [README 插件默认值说明](../README.md)。
 
 装完在会话里跑 **`/videonote-setup`** 收尾：体检 → 引导填 key → 转写模型下载 → 展示默认值 → B站扫码 → 数据管理。
 

--- a/docs/04-使用手册.md
+++ b/docs/04-使用手册.md
@@ -25,7 +25,10 @@
 | 三 · uv tool install | `uv tool install --from git+https://github.com/HuangYincan/VideoNote-MCP videonote` + `claude mcp add videonote -- "$HOME/.local/bin/videonote"` | 固定版本、启动最快 |
 | 四 · 克隆 + install.sh | `git clone https://github.com/HuangYincan/VideoNote-MCP.git && cd VideoNote-MCP && ./install.sh` | 无 uv 兜底，自动弹 setup |
 
-装完重启 Claude Code 会话（或 `/reload-plugins`），`claude mcp list` 应能看到 `videonote`。
+装完重启 Claude Code 会话（或 `/reload-plugins`）生效。**方式一（marketplace）的 MCP 由插件提供**，`claude mcp list` 不会列出它（插件 server 独立注册）；在会话里直接可用工具、或跑 `/videonote-setup` 验证。方式二/四（用户级 `claude mcp add`）`claude mcp list` 会显示 `videonote`。
+
+> [!WARNING] 混合安装注意
+> 若此前用「方式二」或旧版 `install.sh` 加过**用户级** `claude mcp add videonote`，该条目 `env` 为空，会**遮蔽插件自带 MCP server 的 env**（`/plugin` 安装时填的 userConfig 默认值不生效）。用 `claude mcp remove videonote` 移除，让插件 server 接管（命令相同 `uvx --from ...@dev videonote`、同数据目录，无功能损失）。新装请直接走**方式一**，不要再手动 `claude mcp add`。
 
 ## 配置（装完必做）
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **新插件命令 `/videonote-setup`**（`commands/videonote-setup.md`）：装完配置的显式入口 —— 体检 → 引导填 key → 转写模型下载 → 展示默认值 → B站扫码 → 数据管理。
 - **SKILL / reference/tools.md / README（中英）/ docs/04 同步**：凭证命令改为「本会话 `!` 前缀」引导（`! videonote providers set` 隐藏输入、值不过对话；`! videonote login bilibili` 二维码渲染进会话终端）；全自动模式默认来源补 userConfig。
 - **install.sh 修混合安装冲突**：旧版同时做用户级 `claude mcp add videonote`（env 为空）和 marketplace 插件安装，前者会遮蔽插件自带 MCP server 的 env —— 改为 marketplace 优先、仅失败时回退用户级 `claude mcp add` + 本地 Skill 链接；docs/04 加「混合安装注意」警示。
+- **userConfig 说明补全**：`/plugin configure` 页是键盘输入而非下拉选（schema 无 enum）——布尔项点开关、目录项浏览、字符串项直接输入英文 key；`plugin.json` 的 description 逐项写明可填值，README（中英）/ docs/04 补「插件默认值怎么填」说明。
 
 ## 维护（2026-08-06 · 发布 v0.1.4）
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
 - **SKILL / reference/tools.md / README（中英）/ docs/04 同步**：凭证命令改为「本会话 `!` 前缀」引导（`! videonote providers set` 隐藏输入、值不过对话；`! videonote login bilibili` 二维码渲染进会话终端）；全自动模式默认来源补 userConfig。
 - **install.sh 修混合安装冲突**：旧版同时做用户级 `claude mcp add videonote`（env 为空）和 marketplace 插件安装，前者会遮蔽插件自带 MCP server 的 env —— 改为 marketplace 优先、仅失败时回退用户级 `claude mcp add` + 本地 Skill 链接；docs/04 加「混合安装注意」警示。
 - **userConfig 说明补全**：`/plugin configure` 页**全部为键盘输入**（无下拉/开关，schema 无 enum）——布尔项输入 `true`/`false`、目录项输入绝对路径、字符串项直接输入英文 key；`plugin.json` 的 description 逐项写明可填值，README（中英）/ docs/04 补「插件默认值怎么填」说明。
+- **防「装完没重启就配置」**：`/videonote-setup` 命令加**第 0 步「确认 MCP 工具已挂载」**——未挂载（`mcp__videonote__*` 不存在，通常是插件装完没重启会话）→ 立即停止并引导重启 / `/mcp` 排查 / `MCP_TIMEOUT` 重试，禁止 agent 用 CLI/读文件/猜数据目录代替 MCP 工具；SKILL 工作流第 1 步同步；docs/04 明确「重启前不要跑 /videonote-setup」。
 
 ## 维护（2026-08-06 · 发布 v0.1.4）
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@
 - **新插件命令 `/videonote-setup`**（`commands/videonote-setup.md`）：装完配置的显式入口 —— 体检 → 引导填 key → 转写模型下载 → 展示默认值 → B站扫码 → 数据管理。
 - **SKILL / reference/tools.md / README（中英）/ docs/04 同步**：凭证命令改为「本会话 `!` 前缀」引导（`! videonote providers set` 隐藏输入、值不过对话；`! videonote login bilibili` 二维码渲染进会话终端）；全自动模式默认来源补 userConfig。
 - **install.sh 修混合安装冲突**：旧版同时做用户级 `claude mcp add videonote`（env 为空）和 marketplace 插件安装，前者会遮蔽插件自带 MCP server 的 env —— 改为 marketplace 优先、仅失败时回退用户级 `claude mcp add` + 本地 Skill 链接；docs/04 加「混合安装注意」警示。
-- **userConfig 说明补全**：`/plugin configure` 页是键盘输入而非下拉选（schema 无 enum）——布尔项点开关、目录项浏览、字符串项直接输入英文 key；`plugin.json` 的 description 逐项写明可填值，README（中英）/ docs/04 补「插件默认值怎么填」说明。
+- **userConfig 说明补全**：`/plugin configure` 页**全部为键盘输入**（无下拉/开关，schema 无 enum）——布尔项输入 `true`/`false`、目录项输入绝对路径、字符串项直接输入英文 key；`plugin.json` 的 description 逐项写明可填值，README（中英）/ docs/04 补「插件默认值怎么填」说明。
 
 ## 维护（2026-08-06 · 发布 v0.1.4）
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 按关键节点记录项目变更（日期 + 做了什么 + 文档改了什么）。
 
+## 维护（2026-08-16 · setup 整合进 Claude Code /plugin）
+
+把 `videonote setup` 的**默认值类配置**整合进 Claude Code 插件安装体验（凭证类仍走终端，红线不变）：
+
+- **`plugin.json` 加 `userConfig`**：`/plugin install` 时 Claude Code 逐项提示收非敏感默认值（笔记风格 / 截图 / 视频理解 / 评论弹幕 / 转写引擎 / 模型尺寸 / 笔记位置），**API key 不进 userConfig**（K1 决策，key 仍走 `! videonote providers set`）。
+- **`marketplace.json` mcpServers 加 `env`**：`${user_config.*}` → `VIDEONOTE_*` / `TRANSCRIBER_TYPE` / `WHISPER_MODEL_SIZE` 注入 MCP server，作为「配置文件缺项时的兜底默认」。
+- **`config.py` 新增占位符剔除 + env 解析助手**：`_purge_placeholder_env()` 在 `setup_environment()` 最前剔除 Claude Code 对「用户跳过未填项」透传的字面 `${user_config.x}`（防坏字符串当真实配置）；`env_or` / `env_bool` / `env_int` / `env_json_list` 供「配置文件优先、env 兜底」读取点解析。
+- **`server.py` 默认值读取点加 env 兜底**：`generate_note` / `prepare_note_material` / `summarize_note` / `export_transcript` / 自动导出的 style / screenshot / video_understanding / video_interval / include_comments / comments_limit / default_export_formats 全部按「配置文件优先、env 兜底」读取（与 transcriber 现有模式一致）。
+- **新插件命令 `/videonote-setup`**（`commands/videonote-setup.md`）：装完配置的显式入口 —— 体检 → 引导填 key → 转写模型下载 → 展示默认值 → B站扫码 → 数据管理。
+- **SKILL / reference/tools.md / README（中英）/ docs/04 同步**：凭证命令改为「本会话 `!` 前缀」引导（`! videonote providers set` 隐藏输入、值不过对话；`! videonote login bilibili` 二维码渲染进会话终端）；全自动模式默认来源补 userConfig。
+
 ## 维护（2026-08-06 · 发布 v0.1.4）
 
 v0.1.3 → v0.1.4 的主要变更（稳定安装：`uvx --from git+https://github.com/HuangYincan/VideoNote-MCP@v0.1.4 videonote`）：

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **`server.py` 默认值读取点加 env 兜底**：`generate_note` / `prepare_note_material` / `summarize_note` / `export_transcript` / 自动导出的 style / screenshot / video_understanding / video_interval / include_comments / comments_limit / default_export_formats 全部按「配置文件优先、env 兜底」读取（与 transcriber 现有模式一致）。
 - **新插件命令 `/videonote-setup`**（`commands/videonote-setup.md`）：装完配置的显式入口 —— 体检 → 引导填 key → 转写模型下载 → 展示默认值 → B站扫码 → 数据管理。
 - **SKILL / reference/tools.md / README（中英）/ docs/04 同步**：凭证命令改为「本会话 `!` 前缀」引导（`! videonote providers set` 隐藏输入、值不过对话；`! videonote login bilibili` 二维码渲染进会话终端）；全自动模式默认来源补 userConfig。
+- **install.sh 修混合安装冲突**：旧版同时做用户级 `claude mcp add videonote`（env 为空）和 marketplace 插件安装，前者会遮蔽插件自带 MCP server 的 env —— 改为 marketplace 优先、仅失败时回退用户级 `claude mcp add` + 本地 Skill 链接；docs/04 加「混合安装注意」警示。
 
 ## 维护（2026-08-06 · 发布 v0.1.4）
 

--- a/install.sh
+++ b/install.sh
@@ -23,37 +23,34 @@ if [ ! -x "$BIN" ]; then
   exit 1
 fi
 
-echo "==> 2/4 注册 MCP（用户级）"
-if command -v claude >/dev/null 2>&1; then
-  claude mcp add videonote -- "$BIN" && echo "已注册：claude mcp add videonote -- $BIN"
-else
-  echo "未找到 claude CLI。请手动把下面的配置加入你的 MCP 配置："
-  echo "  { \"mcpServers\": { \"videonote\": { \"command\": \"$BIN\" } } }"
-fi
-
-echo "==> 3/4 安装 Skill"
+echo "==> 2/3 安装 Skill + 注册 MCP"
 HAVE_UV="0"
 command -v uv >/dev/null 2>&1 && HAVE_UV="1"
-install_skill_local() {
+PLUGIN_OK="0"
+# 优先走 marketplace：Skill + MCP server 一起装，插件自带 MCP（带 userConfig env）。
+# 不要同时做用户级 `claude mcp add`——同名的用户级条目 env 为空，会遮蔽插件 server 的 env。
+if [ "$HAVE_UV" = "1" ] && command -v claude >/dev/null 2>&1; then
+  if claude plugin marketplace add HuangYincan/VideoNote-MCP >/dev/null 2>&1 \
+     && claude plugin install videonote@videonote >/dev/null 2>&1; then
+    echo "Skill + MCP 已通过 marketplace 安装（videonote@videonote）"
+    PLUGIN_OK="1"
+  fi
+fi
+if [ "$PLUGIN_OK" != "1" ]; then
+  # 回退：无 uv 或 marketplace 失败 → 用户级 MCP + 本地 Skill 链接
+  if command -v claude >/dev/null 2>&1; then
+    claude mcp add videonote -- "$BIN" && echo "已注册：claude mcp add videonote -- $BIN"
+  else
+    echo "未找到 claude CLI。请手动把下面的配置加入你的 MCP 配置："
+    echo "  { \"mcpServers\": { \"videonote\": { \"command\": \"$BIN\" } } }"
+  fi
   mkdir -p "$HOME/.claude/skills"
   ln -sfn "$REPO_DIR/skills/videonote" "$HOME/.claude/skills/videonote"
   echo "已本地链接：$HOME/.claude/skills/videonote"
-}
-if [ "$HAVE_UV" = "1" ] && command -v claude >/dev/null 2>&1; then
-  # marketplace 方式（插件里的 MCP server 走 uvx，需要 uv）
-  if claude plugin marketplace add HuangYincan/VideoNote-MCP >/dev/null 2>&1 \
-     && claude plugin install videonote@videonote >/dev/null 2>&1; then
-    echo "Skill 已通过 marketplace 安装（videonote@videonote）"
-  else
-    install_skill_local
-  fi
-else
-  # 无 uv：跳过 marketplace（避免注册出无法启动的 uvx MCP），只用本地链接
-  install_skill_local
 fi
 
 echo ""
-echo "==> 4/4 初始化配置（LLM 供应商 + 语音转写引擎）"
+echo "==> 3/3 初始化配置（LLM 供应商 + 语音转写引擎）"
 if [ -t 0 ]; then
   "$BIN" setup
 else
@@ -62,6 +59,7 @@ fi
 
 echo ""
 echo "==> 安装完成。验证："
-echo "  claude mcp list        # 应看到 videonote"
+echo "  重启 Claude Code 会话后跑 /videonote-setup（体检 / 填 key / 转写）"
 echo "  $BIN providers list    # 确认 LLM key 已填"
 echo "  health_check           # ffmpeg / db / whisper 状态"
+echo "  （marketplace 方式的 MCP 由插件提供，`claude mcp list` 不会列出；仅回退安装模式会显示）"

--- a/skills/videonote/SKILL.md
+++ b/skills/videonote/SKILL.md
@@ -48,7 +48,7 @@ description: 用 VideoNote-Mcp 的 MCP 工具把视频链接/本地视频（B站
 
 ## 工作流
 
-1. **`health_check`** —— ffmpeg/db 就绪；缺失先让用户装 FFmpeg。
+1. **`health_check`** —— ffmpeg/db 就绪；缺失先让用户装 FFmpeg。**若本会话没有 videonote 的 MCP 工具（`mcp__videonote__*`）**：说明插件 MCP server 未加载，先引导用户**重启会话**（或 `/reload-plugins`），不要用 CLI/读文件代替 MCP 工具。
 2. **`validate_url(url)`** —— 平台识别；B 站优先用平台字幕（AI 字幕需 SESSDATA）。
 3. **`list_providers`** —— 有 key=已填的供应商；没有则让用户在终端配（AGENT 直接生成分支不需要 LLM，但仍需确认已配好）。
 4. **问模式 + 确认参数**（见「强制规则 0/2」，问完再继续）。

--- a/skills/videonote/SKILL.md
+++ b/skills/videonote/SKILL.md
@@ -10,15 +10,15 @@ description: 用 VideoNote-Mcp 的 MCP 工具把视频链接/本地视频（B站
 0. **任务开始必须先问「全自动」还是「手动」**：
    - **全自动**：用 setup 默认解析出本次任务的**完整参数清单**，**一次性列出给用户确认**（不逐个问；用户要改再以提问方式改）—— 见规则 2。`generate_note` / `prepare_note_material` 不传这些参数即套默认。
    - **手动**：逐个确认参数（见规则 2）后再调用 `generate_note`。
-1. **必须用 MCP 工具**（`generate_note` / `prepare_note_material` / `get_task_status` / `list_providers` / `cancel_note` 等），**不要用 Bash/curl 手工调后端**。唯一例外：让用户在独立终端跑 `videonote providers set`（填 key）、`videonote login bilibili`（B站扫码）—— 这些本就该在终端做。
+1. **必须用 MCP 工具**（`generate_note` / `prepare_note_material` / `get_task_status` / `list_providers` / `cancel_note` 等），**不要用 Bash/curl 手工调后端**。唯一例外：让用户在本会话终端输 **`! videonote providers set`**（填 key，隐藏输入、值不过对话）、**`! videonote login bilibili`**（B站扫码）—— 凭证本就该在终端做，`!` 前缀让命令在会话里跑、输出直接进对话。
 2. **确认参数依模式而定**：
    - **手动模式**：用户明确指定（或说「你定」）之前，禁止调用 `generate_note` / `prepare_note_material`。必须问：
      - **LLM 模型**：`list_models(provider_id)` 拿到列表 → 呈现给用户选一个；**或选「AGENT 直接生成」**（`agent_direct`：不用配置 LLM、AGENT 自己写笔记，见强制规则 4；用户要则走工作流分支 A）；
      - **笔记风格**：列出真实 9 种让用户选 —— `minimal` 精简 / `detailed` 详细 / `academic` 学术 / `tutorial` 教程 / `xiaohongshu` 小红书 / `life_journal` 生活向 / `task_oriented` 任务导向 / `business` 商业风格 / `meeting_minutes` 会议纪要，或自定义（描述经 `extras` 传入）；
      - **是否视频理解** + 帧间隔秒数（默认 6，需多模态模型）；
-     - **是否整合弹幕+评论区观点** + 评论条数（默认 20，需 B 站 SESSDATA，没配引导用户 `videonote login bilibili`）；
+     - **是否整合弹幕+评论区观点** + 评论条数（默认 20，需 B 站 SESSDATA，没配引导用户 `! videonote login bilibili`）；
      - **是否插图片** + 笔记保存位置（`notes_dir`）；
-   - **全自动模式**：不逐个问，但**先用 setup 默认解析出本次任务将用的完整参数清单，一次性列给用户确认**（每项带默认值）：
+   - **全自动模式**：不逐个问，但**先用 setup 默认解析出本次任务将用的完整参数清单，一次性列给用户确认**（每项带默认值。默认来源：`/plugin` 安装时的 userConfig 或 `videonote setup` 向导）：
      1. **生成方式 / LLM 模型**：默认用配置 LLM 的默认模型（`list_providers()` 有 key 的供应商默认模型）；**或改选「AGENT 直接生成」**（`agent_direct`，不走配置 LLM、AGENT 自己写笔记，见规则 4 / 分支 A）；
      2. **笔记风格**：`default_style`（默认 detailed，9 种或自定义）；
      3. **视频理解**：默认关（启用则帧间隔 6s，需多模态模型）；
@@ -39,6 +39,12 @@ description: 用 VideoNote-Mcp 的 MCP 工具把视频链接/本地视频（B站
    4. 转写可能很长（如 2h 视频超上下文）→ 用 `get_task_transcript(task_id, segment_range="a-b")` 按段分段精修，或让用户指定重点。
 5. **生成后是否后续优化**：手动模式**生成后必须问**；全自动模式按参数清单已确认的选择执行（要 → 基于笔记（读 `note_dir` 的 note.md）+ 转写精修：`get_task_transcript(task_id)` 按需取转写、超长分段，从转写挖更多细节、展开讲透、补齐遗漏、修正不一致、增强结构；不要 → 跳过），不再重复问。
 6. **平台接手**：`validate_url` / `generate_note` / `prepare_note_material` 返回 `handoff: True` 时，说明该链接不在内置下载器范围（bilibili/youtube/douyin/tiktok/kuaishou/本地文件之外）。**不要重试、不要报错结束**——Agent 接手：用 WebFetch / 浏览器读取页面提取视频源，或用 yt-dlp 通用模式下载，再以本地文件路径调用 `generate_note(video_url="/绝对/路径/x.mp4", platform="local", ...)`。
+
+## 🔧 配置入口（首次使用前）
+
+- **`/videonote-setup`** —— 在 Claude Code 里跑配置向导：体检 → 填 key（`! videonote providers set`）→ 转写引擎/模型下载 → 展示默认值 → B站扫码 → 数据管理。
+- **默认值**：`/plugin` 安装时的 userConfig 已收风格/截图/视频理解/评论/转写引擎/笔记位置等默认；要改跑 `! videonote setup` 全屏向导（独立终端更稳）。
+- **API key 红线**：key 只经 `! videonote providers set` 输入（隐藏、值不过对话），绝不让用户把 key 贴进对话。
 
 ## 工作流
 

--- a/skills/videonote/reference/tools.md
+++ b/skills/videonote/reference/tools.md
@@ -174,12 +174,13 @@
 
 | 场景 | 操作 |
 |------|------|
-| 给内置供应商填 key | 用户在终端 `videonote providers set <id> --api-key 'sk-...'`（agent 不碰 key） |
+| 配置入口（首次使用） | 用户在 Claude Code 跑 `/videonote-setup`（体检 → 填 key → 转写 → 默认值 → B站扫码 → 数据管理） |
+| 给内置供应商填 key | 用户在本会话 `! videonote providers set <id> --api-key 'sk-...'`（隐藏输入、agent 不碰 key） |
 | 自建/新增供应商 | `add_provider(name, api_key, base_url, type)` |
 | 查看供应商 / 模型 | `list_providers()`（掩码）/ `list_models(provider_id)` |
 | 切本地转写 | `set_transcriber("fast-whisper", "small")` + `download_transcriber_model("small")` |
 | 切云端转写 | `set_transcriber("groq")`（groq key 用 CLI 填） |
-| B 站登录/AI 字幕/评论 | 用户在终端 `videonote login bilibili` 扫码（存 SESSDATA）；或 `set_downloader_cookie(platform="bilibili", cookie="SESSDATA=...")` |
+| B 站登录/AI 字幕/评论 | 用户在本会话 `! videonote login bilibili` 扫码（二维码渲染进会话终端，存 SESSDATA）；或 `set_downloader_cookie(platform="bilibili", cookie="SESSDATA=...")` |
 | 本地文件 | `generate_note(video_url="/绝对/路径/x.mp4", platform="local", ...)` |
 | 视频理解默认（setup ③） | 用户说「用默认」/ 全自动模式时不传 `video_understanding`/`video_interval` 即套用（默认关/6s） |
 | 评论/弹幕整合默认（setup ③） | 用户说「用默认」/ 全自动模式时不传 `include_comments`/`comments_limit` 即套用（默认关/20 条） |

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -37,6 +37,15 @@ def test_purge_keeps_real_values():
     del os.environ["VIDEONOTE_DEFAULT_STYLE"]
 
 
+def test_purge_removes_empty_values():
+    # 部分版本对未填 userConfig 传空串而非占位符，同样应剔除走默认
+    os.environ["TRANSCRIBER_TYPE"] = ""
+    os.environ["WHISPER_MODEL_SIZE"] = ""
+    _purge_placeholder_env()
+    assert "TRANSCRIBER_TYPE" not in os.environ
+    assert "WHISPER_MODEL_SIZE" not in os.environ
+
+
 def test_env_or():
     os.environ["VN_TEST"] = "abc"
     assert env_or("VN_TEST") == "abc"

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -1,0 +1,83 @@
+"""videonote_mcp.config 的 env 助手与占位符剔除测试。
+
+背景：Claude Code 插件 userConfig 对「用户跳过未填的项」会透传字面 `${user_config.x}`。
+这些值绝不能当真实配置；`_purge_placeholder_env()` 统一剔除，让下游走默认值。
+`env_or` / `env_bool` / `env_int` / `env_json_list` 是「配置文件优先、env 兜底」
+读取点用的解析助手（userConfig 注入的 env 值都是字符串）。
+"""
+import os
+
+from videonote_mcp.config import (
+    _purge_placeholder_env,
+    env_bool,
+    env_int,
+    env_json_list,
+    env_or,
+    setup_environment,
+)
+
+
+def test_purge_removes_literal_placeholders():
+    os.environ["TRANSCRIBER_TYPE"] = "${user_config.transcriber_type}"
+    os.environ["VIDEONOTE_DEFAULT_STYLE"] = "${user_config.default_style}"
+    os.environ["WHISPER_MODEL_SIZE"] = "${user_config.whisper_model_size}"
+    _purge_placeholder_env()
+    assert "TRANSCRIBER_TYPE" not in os.environ
+    assert "VIDEONOTE_DEFAULT_STYLE" not in os.environ
+    assert "WHISPER_MODEL_SIZE" not in os.environ
+
+
+def test_purge_keeps_real_values():
+    os.environ["TRANSCRIBER_TYPE"] = "groq"
+    os.environ["VIDEONOTE_DEFAULT_STYLE"] = "minimal"
+    _purge_placeholder_env()
+    assert os.environ["TRANSCRIBER_TYPE"] == "groq"
+    assert os.environ["VIDEONOTE_DEFAULT_STYLE"] == "minimal"
+    del os.environ["TRANSCRIBER_TYPE"]
+    del os.environ["VIDEONOTE_DEFAULT_STYLE"]
+
+
+def test_env_or():
+    os.environ["VN_TEST"] = "abc"
+    assert env_or("VN_TEST") == "abc"
+    os.environ["VN_TEST"] = "  "
+    assert env_or("VN_TEST") is None
+    os.environ.pop("VN_TEST", None)
+    assert env_or("VN_TEST") is None
+
+
+def test_env_bool():
+    os.environ["VN_TEST"] = "true"
+    assert env_bool("VN_TEST") is True
+    os.environ["VN_TEST"] = "True"
+    assert env_bool("VN_TEST") is True
+    os.environ["VN_TEST"] = "0"
+    assert env_bool("VN_TEST") is False
+    os.environ.pop("VN_TEST", None)
+    assert env_bool("VN_TEST", default=True) is True
+
+
+def test_env_int():
+    os.environ["VN_TEST"] = "6"
+    assert env_int("VN_TEST", 0) == 6
+    os.environ["VN_TEST"] = "not-a-number"
+    assert env_int("VN_TEST", 20) == 20
+    os.environ.pop("VN_TEST", None)
+    assert env_int("VN_TEST", 20) == 20
+
+
+def test_env_json_list():
+    os.environ["VN_TEST"] = '["srt", "vtt"]'
+    assert env_json_list("VN_TEST", []) == ["srt", "vtt"]
+    os.environ["VN_TEST"] = "not-json"
+    assert env_json_list("VN_TEST", []) == []
+    os.environ.pop("VN_TEST", None)
+    assert env_json_list("VN_TEST", []) == []
+
+
+def test_setup_environment_purges_then_fills_defaults():
+    os.environ["TRANSCRIBER_TYPE"] = "${user_config.transcriber_type}"
+    setup_environment()
+    # 占位符被剔除后，setdefault 重新填上默认值
+    assert os.environ["TRANSCRIBER_TYPE"] == "fast-whisper"
+    del os.environ["TRANSCRIBER_TYPE"]

--- a/videonote_mcp/config.py
+++ b/videonote_mcp/config.py
@@ -17,6 +17,37 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _IS_SOURCE_CHECKOUT = (_REPO_ROOT / "pyproject.toml").exists()
 
+# Claude Code 插件 userConfig → MCP env 映射的全集。Claude Code 对用户跳过未填的
+# userConfig 项会透传字面 `${user_config.x}`，这些值绝不能当真实配置，由
+# _purge_placeholder_env() 统一剔除，让下游走默认值。
+_USER_CONFIG_MAPPED_ENV = (
+    "TRANSCRIBER_TYPE",
+    "WHISPER_MODEL_SIZE",
+    "VIDEONOTE_ENABLE_PREPROCESS",
+    "VIDEONOTE_DIARIZATION",
+    "VIDEONOTE_NOTES_DIR",
+    "VIDEONOTE_DEFAULT_STYLE",
+    "VIDEONOTE_DEFAULT_SCREENSHOT",
+    "VIDEONOTE_VIDEO_UNDERSTANDING",
+    "VIDEONOTE_VIDEO_INTERVAL",
+    "VIDEONOTE_INCLUDE_COMMENTS",
+    "VIDEONOTE_COMMENTS_LIMIT",
+    "VIDEONOTE_DEFAULT_EXPORT_FORMATS",
+)
+
+
+def _purge_placeholder_env() -> None:
+    """剔除形如 `${...}` 的字面 env 值（Claude Code 对未填 userConfig 的透传）。
+
+    必须在 setup_environment() 里 setdefault 默认值**之前**调用：把字面占位符
+    pop 掉后，setdefault 会重新填上正常默认值（如 TRANSCRIBER_TYPE=fast-whisper），
+    否则一个坏字符串会一路当真实配置用（转写引擎直接挂）。
+    """
+    for name in _USER_CONFIG_MAPPED_ENV:
+        v = os.environ.get(name)
+        if v and v.startswith("${") and v.endswith("}"):
+            os.environ.pop(name, None)
+
 
 def _default_data_dir() -> Path:
     if _IS_SOURCE_CHECKOUT:
@@ -28,8 +59,53 @@ def _default_data_dir() -> Path:
     return base / "videonote-mcp"
 
 
+def env_or(name: str) -> "str | None":
+    """读取 env 字符串；未设置或空串 → None。
+
+    供「配置文件优先、env 兜底」的读取点用（Claude Code 插件 userConfig 注入）。
+    """
+    v = os.environ.get(name)
+    if v is None or not v.strip():
+        return None
+    return v
+
+
+def env_bool(name: str, default: bool = False) -> bool:
+    """解析 env 布尔（'1'/'true'/'yes'/'on'，大小写不敏感）；未设置回 default。"""
+    v = env_or(name)
+    if v is None:
+        return default
+    return v.strip().lower() in ("1", "true", "yes", "on")
+
+
+def env_int(name: str, default: int) -> int:
+    """解析 env 整数；未设置或解析失败回 default。"""
+    v = env_or(name)
+    if v is None:
+        return default
+    try:
+        return int(v)
+    except ValueError:
+        return default
+
+
+def env_json_list(name: str, default):
+    """解析 env JSON 数组（如 '["srt","vtt"]'）；未设置/非法回 default。"""
+    v = env_or(name)
+    if v is None:
+        return default
+    try:
+        import json
+
+        parsed = json.loads(v)
+        return parsed if isinstance(parsed, list) else default
+    except Exception:
+        return default
+
+
 def setup_environment() -> Path:
     """解析数据目录并设置环境变量（仅在没有显式设置时填充默认值）。返回数据根目录 Path。"""
+    _purge_placeholder_env()
     data_dir = Path(os.environ.get("VIDEONOTE_DATA_DIR") or _default_data_dir()).expanduser().resolve()
     data_dir.mkdir(parents=True, exist_ok=True)
 

--- a/videonote_mcp/config.py
+++ b/videonote_mcp/config.py
@@ -37,15 +37,18 @@ _USER_CONFIG_MAPPED_ENV = (
 
 
 def _purge_placeholder_env() -> None:
-    """剔除形如 `${...}` 的字面 env 值（Claude Code 对未填 userConfig 的透传）。
+    """剔除 Claude Code 插件 userConfig 注入 env 的「无效值」。
 
-    必须在 setup_environment() 里 setdefault 默认值**之前**调用：把字面占位符
-    pop 掉后，setdefault 会重新填上正常默认值（如 TRANSCRIBER_TYPE=fast-whisper），
-    否则一个坏字符串会一路当真实配置用（转写引擎直接挂）。
+    两种都会被剔除，让下游走默认值：
+      1. 字面 `${...}`（Claude Code 对用户跳过未填项的原样透传）；
+      2. 空字符串（部分版本对未填项传空串而非占位符）。
+    必须在 setup_environment() 里 setdefault 默认值**之前**调用：pop 掉后
+    setdefault 会重新填上正常默认值（如 TRANSCRIBER_TYPE=fast-whisper），
+    否则坏值会一路当真实配置用（转写引擎直接挂）。
     """
     for name in _USER_CONFIG_MAPPED_ENV:
         v = os.environ.get(name)
-        if v and v.startswith("${") and v.endswith("}"):
+        if not v or (v.startswith("${") and v.endswith("}")):
             os.environ.pop(name, None)
 
 

--- a/videonote_mcp/server.py
+++ b/videonote_mcp/server.py
@@ -22,7 +22,7 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Callable, Dict, List, Optional
 
-from videonote_mcp.config import get_app_config, setup_environment
+from videonote_mcp.config import env_bool, env_int, env_json_list, env_or, get_app_config, setup_environment
 
 DATA_DIR = setup_environment()
 
@@ -205,10 +205,10 @@ def _auto_export_transcript(task_id: str, transcript) -> None:
     不涉及 LLM/网络；导出文件自动记入 manifest（供 cleanup_note 清理）。
     """
     try:
-        from videonote_mcp.config import get_app_config
+        from videonote_mcp.config import env_json_list, get_app_config
         from videonote_mcp.export import export_transcript
 
-        default_formats = get_app_config().get("default_export_formats") or []
+        default_formats = get_app_config().get("default_export_formats") or env_json_list("VIDEONOTE_DEFAULT_EXPORT_FORMATS", [])
         if not default_formats or not transcript:
             return
         export_transcript(
@@ -464,21 +464,21 @@ def generate_note(
     # 视频理解默认：参数没传（None）时用 setup ③ 配置的默认（默认关 / 0→6s）；
     # 显式传 False/0/具体秒数仍是显式值，覆盖默认
     if video_understanding is None:
-        video_understanding = bool(get_app_config().get("video_understanding", False))
+        video_understanding = bool(get_app_config().get("video_understanding", env_bool("VIDEONOTE_VIDEO_UNDERSTANDING", False)))
     if video_interval is None:
-        video_interval = int(get_app_config().get("video_interval") or 0)
+        video_interval = int(get_app_config().get("video_interval") or env_int("VIDEONOTE_VIDEO_INTERVAL", 0))
 
     # 弹幕/评论默认：参数没传（None）时用 setup 配置的默认（默认关 / 20 条）
     if include_comments is None:
-        include_comments = bool(get_app_config().get("include_comments", False))
+        include_comments = bool(get_app_config().get("include_comments", env_bool("VIDEONOTE_INCLUDE_COMMENTS", False)))
     if comments_limit is None:
-        comments_limit = int(get_app_config().get("comments_limit") or 20)
+        comments_limit = int(get_app_config().get("comments_limit") or env_int("VIDEONOTE_COMMENTS_LIMIT", 20))
 
     # 风格/截图默认：参数没传（None）时用 setup ③ 配置的默认（默认 detailed / 关）
     if style is None:
-        style = get_app_config().get("default_style") or "detailed"
+        style = get_app_config().get("default_style") or env_or("VIDEONOTE_DEFAULT_STYLE") or "detailed"
     if screenshot is None:
-        screenshot = bool(get_app_config().get("default_screenshot", False))
+        screenshot = bool(get_app_config().get("default_screenshot", env_bool("VIDEONOTE_DEFAULT_SCREENSHOT", False)))
 
     # 并发上限：最多 VIDEONOTE_MAX_WORKERS 个进行中任务（默认 3）—— subagent 并行提交多视频时
     # 按 pool 容量限制，超出则拒绝（避免无界排队）。stderr 管道死锁已修复，并行提交不再挂起。
@@ -558,15 +558,15 @@ def prepare_note_material(
     # 视频理解（抽帧）默认：参数没传（None）时用 setup ③ 配置的默认（默认关 / 0→6s）；
     # 显式传 False/0/具体秒数仍是显式值，覆盖默认
     if video_understanding is None:
-        video_understanding = bool(get_app_config().get("video_understanding", False))
+        video_understanding = bool(get_app_config().get("video_understanding", env_bool("VIDEONOTE_VIDEO_UNDERSTANDING", False)))
     if video_interval is None:
-        video_interval = int(get_app_config().get("video_interval") or 0)
+        video_interval = int(get_app_config().get("video_interval") or env_int("VIDEONOTE_VIDEO_INTERVAL", 0))
 
     # 弹幕/评论默认：参数没传（None）时用 setup 配置的默认（默认关 / 20 条）
     if include_comments is None:
-        include_comments = bool(get_app_config().get("include_comments", False))
+        include_comments = bool(get_app_config().get("include_comments", env_bool("VIDEONOTE_INCLUDE_COMMENTS", False)))
     if comments_limit is None:
-        comments_limit = int(get_app_config().get("comments_limit") or 20)
+        comments_limit = int(get_app_config().get("comments_limit") or env_int("VIDEONOTE_COMMENTS_LIMIT", 20))
 
     # 并发上限：与 generate_note 一致，最多 VIDEONOTE_MAX_WORKERS 个进行中任务（默认 3）
     with _tasks_lock:
@@ -1046,7 +1046,7 @@ def summarize_note(
             f"供应商 {provider_id} 还没有可用模型：请先 list_models 查看，或 add_model 添加模型名"
         )
     if style is None:
-        style = get_app_config().get("default_style") or "detailed"
+        style = get_app_config().get("default_style") or env_or("VIDEONOTE_DEFAULT_STYLE") or "detailed"
     material = {
         "title": title,
         "transcript": _coerce_transcript(transcript),
@@ -1397,9 +1397,9 @@ def export_transcript(
         )
 
     if formats is None:
-        from videonote_mcp.config import get_app_config
+        from videonote_mcp.config import env_json_list, get_app_config
 
-        formats = get_app_config().get("default_export_formats") or ["srt", "vtt", "json"]
+        formats = get_app_config().get("default_export_formats") or env_json_list("VIDEONOTE_DEFAULT_EXPORT_FORMATS", ["srt", "vtt", "json"])
 
     out = out_dir or str(task_dir / "gen")
     written = _export(transcript, formats=formats, out_dir=out, task_id=task_id)


### PR DESCRIPTION
合并 dev → main 的新功能与修复:

- plugin.json 加 userConfig(默认值)+ mcpServers + commands
- marketplace.json 移除 mcpServers(移到 plugin.json,修复插件 MCP server 不注册)
- config.py 加 _purge_placeholder_env + env 解析助手;server.py 默认值 env 兜底
- commands/videonote-setup.md / SKILL / README(中英) / docs 同步
- install.sh 修混合安装冲突