### PR TITLE
docs(readme): 快速开始精简 —— 步骤3收敛为 `! videonote setup`,同步 EN/docs/04

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,27 +52,14 @@ claude plugin install videonote@videonote
 #    装完在会话里跑配置向导收尾：
 /videonote-setup
 
-# 3) 填 LLM key（隐藏输入，值不进对话）：在本会话输入
-#    ! videonote providers set <provider_id> --api-key 'sk-...'
-#    （B 站扫码：! videonote login bilibili；全屏向导：! videonote setup，独立终端更稳）
+# 3) （可选）LLM-Key/B 站扫码/CLI向导
+# ! videonote setup
 
 # 4) 重启会话，对 agent 说「帮我给这个视频做笔记」+ 链接
 ```
 
 > [!TIP] 
 > 四种安装方式、配置细节、更新与安全见 [docs/04-使用手册.md](docs/04-使用手册.md)。
-> 
-
-> [!NOTE] 插件默认值怎么填（`/plugin configure` 页）
-> `/plugin install` 时及 `/plugin configure` 页里的默认值项**全部手动输入**（无下拉/开关）：
-> - **布尔项**（笔记默认插图 / 视频理解默认 / 弹幕+评论整合默认）：输入 `true` 或 `false`；
-> - **目录项**（笔记默认位置）：输入笔记输出目录的**绝对路径**，留空 = 默认 `note_results/{task_id}/`；
-> - **字符串项**（笔记风格 / 转写引擎 / 模型尺寸）：**直接输入英文 key** ——
->   风格：`detailed` / `minimal` / `academic` / `tutorial` / `xiaohongshu` / `life_journal` / `task_oriented` / `business` / `meeting_minutes`；
->   转写引擎：`fast-whisper`（本地，推荐）/ `groq` / `bcut` / `kuaishou` / `mlx-whisper`；
->   模型尺寸：`tiny` / `base` / `small` / `medium` / `large-v3` / `large-v3-turbo`。
-> 这些只是「配置文件缺项时的兜底默认」——你本地用 `videonote setup` 配置的
-> `app_config.json` / `transcriber.json` 优先级更高，只有它们没设某项时才用这里的值。
 
 ## 📚 文档
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -51,29 +51,13 @@ claude plugin install videonote@videonote
 #    video-understanding / comments etc.); then run the guided config command:
 /videonote-setup
 
-# 3) Fill in your LLM key (hidden input, never enters the conversation) — type
-#    in this session:
-#    ! videonote providers set <provider_id> --api-key 'sk-...'
-#    (Bilibili QR login: ! videonote login bilibili; full wizard:
-#    ! videonote setup — better in a separate terminal)
+# 3) (Optional) LLM key / Bilibili QR login / CLI wizard:
+# ! videonote setup
 
 # 4) Restart your session, tell the agent "make notes for this video" + link
 ```
 
 > All four install methods, configuration details, updating and security are in [docs/04-使用手册.md](docs/04-使用手册.md).
-
-> [!NOTE] How to fill in the plugin defaults (`/plugin configure` page)
-> The default-value fields shown during `/plugin install` and on the `/plugin configure`
-> page are **all typed input** (no dropdowns or toggles):
-> - **Boolean fields** (Default screenshots / Video understanding / Comments): type `true` or `false`;
-> - **Directory field** (Default notes location): type an **absolute path**; leave empty for the default `note_results/{task_id}/`;
-> - **String fields** (Style / Transcriber / Model size): **type the English key directly** —
->   style: `detailed` / `minimal` / `academic` / `tutorial` / `xiaohongshu` / `life_journal` / `task_oriented` / `business` / `meeting_minutes`;
->   transcriber: `fast-whisper` (local, recommended) / `groq` / `bcut` / `kuaishou` / `mlx-whisper`;
->   model size: `tiny` / `base` / `small` / `medium` / `large-v3` / `large-v3-turbo`.
-> These only serve as **fallbacks when the config file lacks a value** — your local
-> `app_config.json` / `transcriber.json` (set via `videonote setup`) takes precedence.
-
 
 ## 📚 Docs
 

--- a/docs/04-使用手册.md
+++ b/docs/04-使用手册.md
@@ -38,7 +38,7 @@
 
 `/plugin install` 时 Claude Code 会**逐项提示填默认值**（笔记风格 / 转写引擎 / 模型尺寸 / 视频理解 / 评论弹幕 / 笔记位置，均非敏感）——存 Claude Code 配置，经 MCP `env` 注入 server，作为「配置文件缺项时的兜底默认」（配置文件优先，之后跑 `setup` 向导修改仍以向导为准）。
 
-**填法**（`/plugin configure` 页**全部为键盘输入**，无下拉/开关）：布尔项（插图/视频理解/评论）输入 `true`/`false`；目录项（笔记位置）输入**绝对路径**，留空 = 默认；字符串项（风格/引擎/尺寸）直接输入英文 key —— 风格 `detailed`/`minimal`/`academic`/`tutorial`/`xiaohongshu`/`life_journal`/`task_oriented`/`business`/`meeting_minutes`；引擎 `fast-whisper`/`groq`/`bcut`/`kuaishou`/`mlx-whisper`；尺寸 `tiny`/`base`/`small`/`medium`/`large-v3`/`large-v3-turbo`。详情见 [README 插件默认值说明](../README.md)。
+**填法**（`/plugin configure` 页**全部为键盘输入**，无下拉/开关）：布尔项（插图/视频理解/评论）输入 `true`/`false`；目录项（笔记位置）输入**绝对路径**，留空 = 默认；字符串项（风格/引擎/尺寸）直接输入英文 key —— 风格 `detailed`/`minimal`/`academic`/`tutorial`/`xiaohongshu`/`life_journal`/`task_oriented`/`business`/`meeting_minutes`；引擎 `fast-whisper`/`groq`/`bcut`/`kuaishou`/`mlx-whisper`；尺寸 `tiny`/`base`/`small`/`medium`/`large-v3`/`large-v3-turbo`。Configure 页每个字段下方的说明也列出了可填值。
 
 装完在会话里跑 **`/videonote-setup`** 收尾：体检 → 引导填 key → 转写模型下载 → 展示默认值 → B站扫码 → 数据管理。
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 按关键节点记录项目变更（日期 + 做了什么 + 文档改了什么）。
 
+## 维护（2026-08-16 · README 快速开始精简）
+
+- **中文 README 快速开始精简**：步骤 3 收敛为一行 `! videonote setup`（LLM-Key / B 站扫码 / CLI 向导，配置细节交向导与 Configure 页）；删除「插件默认值怎么填」NOTE 块。
+- **README_EN 同步**：步骤 3 同口径精简，删除英文「How to fill in the plugin defaults」NOTE。
+- **docs/04 保留 Configure 填法说明**：修掉对已删 README NOTE 的失效引用（改为「Configure 页每个字段下方的说明也列出了可填值」），填法细节作为详细手册内容保留。
+
 ## 维护（2026-08-16 · setup 整合进 Claude Code /plugin）
 
 把 `videonote setup` 的**默认值类配置**整合进 Claude Code 插件安装体验（凭证类仍走终端，红线不变）：


### PR DESCRIPTION
用户手动精简中文 README 快速开始,同步其余文件:

- README.md(手动改):步骤 3 收敛为一行 `! videonote setup`(LLM-Key/B站扫码/CLI向导);删除「插件默认值怎么填」NOTE
- README_EN.md:同口径精简,删英文 NOTE
- docs/04-使用手册.md:保留 Configure 填法说明,修掉对已删 README NOTE 的失效引用
- docs/CHANGELOG.md:记录