### PR TITLE
chore(release): bump v0.1.6 —— 工具面精简 39→16 + 17 轮全库扫描 + 文档整理

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/local)",
   "author": {
     "name": "HuangYincan",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote-mcp"
-version = "0.1.5"
+version = "0.1.6"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"


### PR DESCRIPTION
版本 bump 0.1.5 → 0.1.6（pyproject / `__init__` / plugin.json 三处一致）。合并后打 tag v0.1.6 触发 release.yml（门禁校验版本与 tag 一致）。