### PR TITLE
fix(ci): release job 缺 setup-uv——uv build command not found 致 tag 发布失败

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/local)",
   "author": {
     "name": "HuangYincan",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v5
+      # uv 不在 runner 默认 PATH（CI job 有 setup-uv，release job 漏了）——
+      # `uv build` command not found（exit 127）致 v0.1.6 首次发布失败
+      - uses: astral-sh/setup-uv@v7
       - name: Verify version matches tag
         run: |
           pkg_version="$(grep -m1 '^version' pyproject.toml | sed -E 's/version = "([^"]+)"/\1/')"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote-mcp"
-version = "0.1.5"
+version = "0.1.6"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"


### PR DESCRIPTION
v0.1.6 tag 触发 release.yml：Verify version 门禁通过，但 Build wheel 步骤 `uv build` command not found（exit 127）——release job 没有 setup-uv（CI job 有）。加 astral-sh/setup-uv@v7。修复后重打 tag v0.1.6 验证。