### PR TITLE
feat(pypi): 上架 PyPI v0.1.7——包名 videonote + trusted publishing

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/local)",
   "author": {
     "name": "HuangYincan",
@@ -13,8 +13,6 @@
     "videonote": {
       "command": "uvx",
       "args": [
-        "--from",
-        "git+https://github.com/HuangYincan/VideoNote-MCP",
         "videonote"
       ],
       "env": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,3 +77,20 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      # Trusted publishing（OIDC）：GitHub Actions 直接以 PyPI 项目身份发布，
+      # 无需 API token 进仓库。前置：PyPI 项目 videonote 的 Publishing 里
+      # 添加 trusted publisher（owner=HuangYincan，repo=VideoNote-MCP，workflow=release.yml）。
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
+      - name: Build wheel and sdist
+        run: uv build
+      - name: Publish to PyPI
+        run: uv publish

--- a/docs/00-新手上路.md
+++ b/docs/00-新手上路.md
@@ -122,7 +122,7 @@ docs: 回填 #N commit hash（<hash>）
    调试 MCP 服务不要依赖 stdout 打印；看日志文件。
 3. **MCP 调试用官方库**：`mcp.client.stdio` 的 `stdio_client` 起真客户端（conftest / ci.yml 有样例），
    不要手写裸 JSON-RPC。
-4. **uvx `--with` 顺序**：`uvx --from git+... --with mlx-whisper videonote ...` —— `--with` 必须在工具名**前**。
+4. **uvx `--with` 顺序**：`uvx --with mlx-whisper videonote ...` —— `--with` 必须在工具名**前**。
 5. **mlx-whisper 仅 macOS**：CI 是 Linux → 平台相关测试必须 `@unittest.skipUnless(sys.platform=="darwin", ...)`。
 6. **`notes_dir` 语义**：是**输出**目录（笔记/导出写往哪），不是素材输入目录；传 `file://` 会规整成本地路径。
 7. **stdout 输出给 MCP 的边界**：stdio 模式下任何 print 都可能污染 JSON-RPC 帧。

--- a/docs/04-使用手册.md
+++ b/docs/04-使用手册.md
@@ -11,7 +11,7 @@
 - **本地转写**：本地 whisper 需先 `videonote transcriber download <size>`，或改用云端 `groq` / `bcut`
 - **GPU 加速（可选）**：NVIDIA/Linux 想用 CUDA → 装工具时 `--with torch`（whisper 自动检测 GPU，默认 CPU）；macOS Apple Silicon → `--with mlx-whisper` + `videonote transcriber set mlx-whisper`
 - **CLI 命令简写**：正文里的 `videonote ...` 等价于：
-  - 有 uv：`uvx --from git+https://github.com/HuangYincan/VideoNote-MCP videonote ...`（`--from` 必须带 `git+` 前缀）
+  - 有 uv：`uvx videonote ...`（PyPI 包 `videonote`，v0.1.7 起）
   - 源码（方式四）：`<仓库路径>/.venv/bin/videonote ...`
 
 ## 安装
@@ -21,14 +21,14 @@
 | 方式 | 命令 | 说明 |
 |------|------|------|
 | 一 · 插件 marketplace（推荐） | `claude plugin marketplace add HuangYincan/VideoNote-MCP` + `claude plugin install videonote@videonote` | Skill + MCP，uvx 自动更新 |
-| 二 · 只装 MCP | `claude mcp add --scope user videonote -- uvx --from git+https://github.com/HuangYincan/VideoNote-MCP videonote` | 仅 MCP |
-| 三 · uv tool install | `uv tool install --from git+https://github.com/HuangYincan/VideoNote-MCP videonote` + `claude mcp add videonote -- "$HOME/.local/bin/videonote"` | 固定版本、启动最快 |
+| 二 · 只装 MCP | `claude mcp add --scope user videonote -- uvx videonote` | 仅 MCP |
+| 三 · uv tool install | `uv tool install videonote` + `claude mcp add videonote -- "$HOME/.local/bin/videonote"` | 固定版本、启动最快 |
 | 四 · 克隆 + install.sh | `git clone https://github.com/HuangYincan/VideoNote-MCP.git && cd VideoNote-MCP && ./install.sh` | 无 uv 兜底，自动弹 setup |
 
 装完**必须重启** Claude Code 会话（或 `/reload-plugins`）才会加载插件的 MCP server —— **重启前不要跑 `/videonote-setup`**（MCP 工具未挂载，命令会停在诊断步）。**方式一（marketplace）的 MCP 由插件提供**，`claude mcp list` 不会列出它（插件 server 独立注册）；重启后在会话里直接可用工具、或跑 `/videonote-setup` 验证。方式二/四（用户级 `claude mcp add`）`claude mcp list` 会显示 `videonote`。
 
 > [!WARNING] 混合安装注意
-> 若此前用「方式二」或旧版 `install.sh` 加过**用户级** `claude mcp add videonote`，该条目 `env` 为空，会**遮蔽插件自带 MCP server 的 env**（`/plugin` 安装时填的 userConfig 默认值不生效）。用 `claude mcp remove videonote` 移除，让插件 server 接管（命令相同 `uvx --from ...@dev videonote`、同数据目录，无功能损失）。新装请直接走**方式一**，不要再手动 `claude mcp add`。
+> 若此前用「方式二」或旧版 `install.sh` 加过**用户级** `claude mcp add videonote`，该条目 `env` 为空，会**遮蔽插件自带 MCP server 的 env**（`/plugin` 安装时填的 userConfig 默认值不生效）。用 `claude mcp remove videonote` 移除，让插件 server 接管（命令相同 `uvx videonote`、同数据目录，无功能损失）。新装请直接走**方式一**，不要再手动 `claude mcp add`。
 
 ## 配置（装完必做）
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "videonote-mcp"
-version = "0.1.6"
+name = "videonote"
+version = "0.1.7"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/uv.lock
+++ b/uv.lock
@@ -4020,8 +4020,8 @@ wheels = [
 ]
 
 [[package]]
-name = "videonote-mcp"
-version = "0.1.5"
+name = "videonote"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/videonote_mcp/cli.py
+++ b/videonote_mcp/cli.py
@@ -494,8 +494,7 @@ def _wizard_transcriber(inq) -> None:
                             file=sys.stdout,
                         )
                         print(
-                            f"{_DIM}`uv tool install --from git+https://github.com/HuangYincan/VideoNote-MCP videonote "
-                            f"--with pyannote.audio --with torch`，或用 `uvx --from ... --with pyannote.audio --with torch` 运行。{_RESET}",
+                            f"{_DIM}`uv tool install --with pyannote.audio --with torch videonote`，或用 `uvx --with pyannote.audio --with torch videonote` 运行。{_RESET}",
                             file=sys.stdout,
                         )
                     hf = inq.secret(message="HuggingFace token（HF_TOKEN，留空跳过）", keybindings=_KB).execute()
@@ -533,8 +532,8 @@ def _wizard_transcriber(inq) -> None:
                     if mlx_missing:
                         print(
                             f"{_YELLOW}⚠ 当前环境未装 mlx-whisper（可选依赖）。{_RESET}"
-                            f"{_DIM}想用 mlx：`uv tool install --from git+https://github.com/HuangYincan/VideoNote-MCP videonote --with mlx-whisper`，"
-                            f"或用 `uvx --from ... --with mlx-whisper` 运行。{_RESET}",
+                            f"{_DIM}想用 mlx：`uv tool install --with mlx-whisper videonote`，"
+                            f"或用 `uvx --with mlx-whisper videonote` 运行。{_RESET}",
                             file=sys.stdout,
                         )
                         if inq.confirm(message="改用 fast-whisper（当前环境可用）？", default=True, keybindings=_KB).execute():
@@ -585,8 +584,7 @@ def _wizard_transcriber(inq) -> None:
                             file=sys.stdout,
                         )
                         print(
-                            f"{_DIM}`uv tool install --from git+https://github.com/HuangYincan/VideoNote-MCP videonote "
-                            f"--with funasr --with torch`，或用 `uvx --from ... --with funasr --with torch` 运行。{_RESET}",
+                            f"{_DIM}`uv tool install --with funasr --with torch videonote`，或用 `uvx --with funasr --with torch videonote` 运行。{_RESET}",
                             file=sys.stdout,
                         )
     except KeyboardInterrupt:
@@ -1365,8 +1363,7 @@ def _transcriber_cli(argv) -> None:
                     file=sys.stdout,
                 )
                 print(
-                    "  `uv tool install --from git+https://github.com/HuangYincan/VideoNote-MCP videonote "
-                    "--with pyannote.audio --with torch`，或用 `uvx --from ... --with pyannote.audio --with torch` 运行。",
+                    "  `uv tool install --with pyannote.audio --with torch videonote`，或用 `uvx --with pyannote.audio --with torch videonote` 运行。",
                     file=sys.stdout,
                 )
                 print(


### PR DESCRIPTION
## 变更

- **包名**：`videonote-mcp` → `videonote`（PyPI 注册名，已确认空闲），版本 0.1.6 → 0.1.7
- **release.yml**：新增 `publish` job（trusted publishing OIDC，免 API token），`uv build` → `uv publish`
- **插件 MCP 命令**：`uvx --from git+...` → `uvx videonote`（启动 ~1s，不再每次 fetch git）
- **cli.py**：4 处安装提示改为 PyPI 简写（顺带修掉 `--from git+... videonote` 包名不匹配的 bug）
- **文档**：CLAUDE.md / docs/00 / docs/04 安装描述更新

## 发布时序（合并后）

1. PyPI 配置 trusted publisher（owner=HuangYincan / repo=VideoNote-MCP / workflow=release.yml）——需用户在 PyPI 页面操作一次
2. 打 tag v0.1.7 → CI 自动 publish 到 PyPI

测试：664 passed + ruff F/I clean