### PR TITLE
fix(pypi): 锁 mcp<2（v0.1.7 启动即崩）+ 握手冒烟 + bump 0.1.8

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/local)",
   "author": {
     "name": "HuangYincan",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,31 @@ jobs:
               sys.exit(1)
           print("✅ wheel 内容完整（%d 个文件）" % len(names))
           EOF
+      # 依赖漂移护栏（v0.1.7 事故）：本地/CI 测试读 uv.lock（锁 1.x），但 wheel 发布后
+      # uvx 按 pyproject 解析最新——mcp 2.0 移除 server.fastmcp 致启动即崩（ModuleNotFoundError）。
+      # 这里对构建出的 wheel 做一次真实 MCP 握手，过不了就不发。
+      - name: MCP handshake smoke on built wheel
+        run: |
+          uv run --with "$(ls dist/*.whl | head -1)" python - <<'PYEOF'
+          import asyncio, glob
+          from mcp import ClientSession, StdioServerParameters, stdio_client
+
+          WHEEL = glob.glob("dist/*.whl")[0]
+
+          async def main():
+              params = StdioServerParameters(
+                  command="uv",
+                  args=["run", "--with", WHEEL, "python", "-m", "videonote_mcp.server"],
+              )
+              async with stdio_client(params) as (r, w):
+                  async with ClientSession(r, w) as s:
+                      info = await s.initialize()
+                      tools = await s.list_tools()
+                      assert len(tools.tools) >= 16, f"tools={len(tools.tools)}"
+                      print(f"✅ 握手 OK: {info.serverInfo.name} {info.serverInfo.version}, tools={len(tools.tools)}")
+
+          asyncio.run(main())
+          PYEOF
       - name: Create release for tag
         uses: softprops/action-gh-release@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote"
-version = "0.1.7"
+version = "0.1.8"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel
@@ -13,9 +13,9 @@ authors = [{ name = "HuangYincan" }]
 # （weasyprint/pdfkit/python-docx/markdown_pdf/PyMuPDF）、gmssl/pycryptodomex/bs4/lxml（下载器未用）。
 dependencies = [
     # MCP SDK：FastMCP 是 mcp 包自带的 mcp.server.fastmcp 子模块（#133 C1）。
-    # 曾误声明独立 fastmcp 包（3.4.x）——全仓零 import，uvx 安装不读 lock 时
-    # 若其放开 mcp 上界/移除 server.fastmcp 会直接挂；改为直接声明实际使用的 mcp。
-    "mcp>=1.29.0",
+    # 曾误声明独立 fastmcp 包（3.4.x）；后 mcp 2.0 移除 server.fastmcp（2026-08-19
+    # 实测 v0.1.7 事故）——uvx 安装不读 lock 解析最新会拿到 2.x 启动即崩，锁 <2。
+    "mcp>=1.29.0,<2",
     "yt-dlp>=2025.3.31",
     "openai>=1.70.0",
     "faster-whisper>=1.1.1",

--- a/uv.lock
+++ b/uv.lock
@@ -4021,7 +4021,7 @@ wheels = [
 
 [[package]]
 name = "videonote"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -4078,7 +4078,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "huggingface-hub", specifier = ">=0.30.0" },
     { name = "inquirerpy", specifier = ">=0.3.4" },
-    { name = "mcp", specifier = ">=1.29.0" },
+    { name = "mcp", specifier = ">=1.29.0,<2" },
     { name = "mlx-whisper", marker = "extra == 'mlx'" },
     { name = "noisereduce", marker = "extra == 'preprocess'" },
     { name = "openai", specifier = ">=1.70.0" },

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"


### PR DESCRIPTION
## 根因（v0.1.7 事故）

`mcp 2.0.0`（今天发布）移除了 `mcp.server.fastmcp` 子模块。本地/CI 测试读 `uv.lock`（锁 1.x）全绿，但 `uvx videonote` / `uv tool install videonote` **不读 lock**，按 pyproject 解析到最新 mcp 2.0.0 → server 启动即崩（ModuleNotFoundError）。

## 修复

1. **pyproject**：`mcp>=1.29.0` → `mcp>=1.29.0,<2`（锁 major，防 2.x 漂移；注释记录事故）
2. **release.yml**：build 后对 wheel 做**真实 MCP 握手冒烟**（官方 mcp 客户端 initialize + list_tools，≥16 工具），过不了不发——防止 lock/解析双轨再次漂移
3. 版本 0.1.7 → 0.1.8

## 验证

- 本地对 `dist/videonote-0.1.8-py3-none-any.whl` 握手：✅ videonote, tools=16
- 664 tests + ruff F/I clean