### PR TITLE
fix(ssrf): 放行 fake-ip 代理段（本机代理下全部 URL 被误拦）

### DIFF
--- a/app/utils/url_safety.py
+++ b/app/utils/url_safety.py
@@ -46,8 +46,18 @@ def sanitize_url(url: Optional[str]) -> str:
     return f"{parts.scheme}://{host}{parts.path or '/'}"
 
 
+# fake-ip 代理（Clash/Surge/Stash 等 macOS 常用）把 DNS 解析结果返回
+# 198.18.0.0/15（RFC 2544 benchmarking 段，公网不可路由，真实内网不使用），
+# 流量由代理转发到公网——is_global 判 False 会误杀所有 URL（2026-08-19
+# 用户实测：本机代理下 generate_note/inspect_video 全部被 SSRF 防护拦截）。
+# 放行该段不削弱防护目标：内网/环回/元数据端点（169.254.169.254）仍全拦。
+_FAKE_IP_PROXY_NET = ipaddress.ip_network("198.18.0.0/15")
+
+
 def _ip_is_global(ip: ipaddress._BaseAddress) -> bool:
     """IPv4/IPv6 统一判公网。is_global 聚合了 private/loopback/link_local/reserved/unspecified/multicast。"""
+    if ip.version == 4 and ip in _FAKE_IP_PROXY_NET:
+        return True
     try:
         return bool(ip.is_global)
     except Exception:  # noqa: BLE001 —— 个别保留区间 is_global 可能抛错，保守拦截

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -44,6 +44,19 @@ class TestIsPublicHttpUrlLiteralIp:
     def test_public_ip_allowed(self, url):
         assert is_public_http_url(url) is True
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://198.18.0.1/x",      # fake-ip 代理段起点
+            "http://198.18.5.33/x",     # fake-ip（Clash 默认）
+            "http://198.19.255.255/x",  # fake-ip 段终点
+        ],
+    )
+    def test_fake_ip_proxy_range_allowed(self, url):
+        """198.18.0.0/15（RFC 2544）：Clash/Surge fake-ip 代理的 DNS 返回段，
+        流量经代理转发公网，is_global=False 会误杀（2026-08-19 实测）。"""
+        assert is_public_http_url(url) is True
+
 
 class TestIsPublicHttpUrlScheme:
     @pytest.mark.parametrize(
@@ -71,6 +84,15 @@ class TestIsPublicHttpUrlHostname:
 
         with mock.patch("socket.getaddrinfo", side_effect=_private):
             assert is_public_http_url("http://internal.example.com/x") is False
+
+    def test_host_resolves_to_fake_ip_allowed(self):
+        """域名解析到 fake-ip 段（198.18.0.0/15）不拦截——代理转发公网。"""
+
+        def _fake_ip(*_a, **_k):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("198.18.0.1", 0))]
+
+        with mock.patch("socket.getaddrinfo", side_effect=_fake_ip):
+            assert is_public_http_url("http://example.com/v") is True
 
     def test_host_resolves_to_public_allowed(self):
         assert is_public_http_url("http://example.com/v") is True  # conftest 桩成 8.8.8.8


### PR DESCRIPTION
## 问题（用户实测）

本机 Clash/Surge 类代理开 fake-ip 模式时，DNS 解析返回 198.18.0.0/15（RFC 2544 benchmarking 段）→ `is_global=False` → `generate_note` / `inspect_video` 的 SSRF 防护**拦截所有公网 URL**——核心功能不可用，Agent 被迫绕路（本地下载→抓字幕→手动写笔记）。

## 修复

`app/utils/url_safety.py`：`_ip_is_global` 放行 `198.18.0.0/15`。

- 该段公网不可路由、真实内网不使用，流量经代理转发到公网
- 防护目标（内网/环回/元数据端点 169.254.169.254 等）仍全拦

## 测试

+4：fake-ip 段字面 IP ×3（起点/Clash 默认/终点）、域名解析到 fake-ip ×1。668 passed + ruff F/I clean