### PR TITLE
chore(release): bump v0.1.9（fake-ip SSRF 修复随版发布）

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/local)",
   "author": {
     "name": "HuangYincan",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote"
-version = "0.1.8"
+version = "0.1.9"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/uv.lock
+++ b/uv.lock
@@ -4021,7 +4021,7 @@ wheels = [
 
 [[package]]
 name = "videonote"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"


### PR DESCRIPTION
三处版本 0.1.8 → 0.1.9（fae2b5f 的 fake-ip 修复需发版生效）