### PR TITLE
fix(ssrf): IPv6 fake-ip 段 fdfe::/16 放行 + bump 0.1.10

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/local)",
   "author": {
     "name": "HuangYincan",

--- a/app/utils/url_safety.py
+++ b/app/utils/url_safety.py
@@ -46,17 +46,22 @@ def sanitize_url(url: Optional[str]) -> str:
     return f"{parts.scheme}://{host}{parts.path or '/'}"
 
 
-# fake-ip 代理（Clash/Surge/Stash 等 macOS 常用）把 DNS 解析结果返回
-# 198.18.0.0/15（RFC 2544 benchmarking 段，公网不可路由，真实内网不使用），
+# fake-ip 代理（Clash/Surge/Stash 等 macOS 常用）把 DNS 解析结果返回保留段，
 # 流量由代理转发到公网——is_global 判 False 会误杀所有 URL（2026-08-19
-# 用户实测：本机代理下 generate_note/inspect_video 全部被 SSRF 防护拦截）。
-# 放行该段不削弱防护目标：内网/环回/元数据端点（169.254.169.254）仍全拦。
-_FAKE_IP_PROXY_NET = ipaddress.ip_network("198.18.0.0/15")
+# 用户实测：双栈 fake-ip 下 generate_note/inspect_video 全部被 SSRF 防护拦截）。
+#   IPv4：198.18.0.0/15（RFC 2544 benchmarking 段，公网不可路由，真实内网不使用）
+#   IPv6：fdfe::/16（Clash/Surge fake-ip v6 默认段，ULA fd00::/8 随机段；真实内网
+#        几乎不用 fdfe 前缀，其余 fc00::/7 ULA 仍拦）
+# 放行这两个段不削弱防护目标：内网/环回/元数据端点（169.254.169.254）仍全拦。
+_FAKE_IP_PROXY_NETS = (
+    ipaddress.ip_network("198.18.0.0/15"),
+    ipaddress.ip_network("fdfe::/16"),
+)
 
 
 def _ip_is_global(ip: ipaddress._BaseAddress) -> bool:
     """IPv4/IPv6 统一判公网。is_global 聚合了 private/loopback/link_local/reserved/unspecified/multicast。"""
-    if ip.version == 4 and ip in _FAKE_IP_PROXY_NET:
+    if any(ip in net for net in _FAKE_IP_PROXY_NETS):
         return True
     try:
         return bool(ip.is_global)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote"
-version = "0.1.9"
+version = "0.1.10"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -50,10 +50,12 @@ class TestIsPublicHttpUrlLiteralIp:
             "http://198.18.0.1/x",      # fake-ip 代理段起点
             "http://198.18.5.33/x",     # fake-ip（Clash 默认）
             "http://198.19.255.255/x",  # fake-ip 段终点
+            "https://[fdfe::1]/x",      # fake-ip v6 段（Clash/Surge 默认 fdfe::/16）
+            "https://[fdfe:dcba:9876::68]/x",  # 实测解析出的 IPv6 fake-ip
         ],
     )
     def test_fake_ip_proxy_range_allowed(self, url):
-        """198.18.0.0/15（RFC 2544）：Clash/Surge fake-ip 代理的 DNS 返回段，
+        """fake-ip 代理段（198.18.0.0/15 + fdfe::/16）：Clash/Surge 的 DNS 返回段，
         流量经代理转发公网，is_global=False 会误杀（2026-08-19 实测）。"""
         assert is_public_http_url(url) is True
 
@@ -86,13 +88,26 @@ class TestIsPublicHttpUrlHostname:
             assert is_public_http_url("http://internal.example.com/x") is False
 
     def test_host_resolves_to_fake_ip_allowed(self):
-        """域名解析到 fake-ip 段（198.18.0.0/15）不拦截——代理转发公网。"""
+        """域名解析到 fake-ip 段（IPv6 fdfe::/16 + IPv4 198.18.0.0/15 双栈，
+        模拟 Clash/Surge 真实 getaddrinfo 顺序）不拦截——代理转发公网。"""
 
         def _fake_ip(*_a, **_k):
-            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("198.18.0.1", 0))]
+            return [
+                (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("fdfe:dcba:9876::68", 0, 0, 0)),
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("198.18.0.102", 0)),
+            ]
 
         with mock.patch("socket.getaddrinfo", side_effect=_fake_ip):
             assert is_public_http_url("http://example.com/v") is True
+
+    def test_host_resolves_to_non_fake_ula_blocked(self):
+        """fc00::/7 的其他 ULA 段（非 fdfe::/16）仍拦截——fake-ip 放行不扩大化。"""
+
+        def _ula(*_a, **_k):
+            return [(socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("fc00::1", 0, 0, 0))]
+
+        with mock.patch("socket.getaddrinfo", side_effect=_ula):
+            assert is_public_http_url("http://internal.example.com/v") is False
 
     def test_host_resolves_to_public_allowed(self):
         assert is_public_http_url("http://example.com/v") is True  # conftest 桩成 8.8.8.8

--- a/uv.lock
+++ b/uv.lock
@@ -4021,7 +4021,7 @@ wheels = [
 
 [[package]]
 name = "videonote"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"


### PR DESCRIPTION
## 问题（0.1.9 实测仍拦）

双栈 fake-ip 代理：DNS 同时返回 IPv6 ULA（`fdfe::/16`，Clash/Surge fake-ip v6 默认段）+ IPv4（198.18/15）。0.1.9 只放了 IPv4——`_host_is_public` 的「任一非公网即拦截」被 IPv6 ULA 拦截。

## 修复

`_FAKE_IP_PROXY_NETS` 加 `fdfe::/16`（ULA fd00::/8 随机段，真实内网几乎不用 fdfe 前缀；fc00::/7 其余仍拦）。

## 测试

+3：fdfe 字面 IP ×2、双栈域名解析（IPv6+IPv4 混合顺序）放行、非 fdfe ULA（fc00::1）仍拦。671 passed + ruff F/I clean