### PR TITLE
feat: videonote proxy + cookie 子命令 + bump 0.1.11

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/local)",
   "author": {
     "name": "HuangYincan",

--- a/app/downloaders/youtube_downloader.py
+++ b/app/downloaders/youtube_downloader.py
@@ -34,10 +34,12 @@ def _apply_proxy(ydl_opts: dict) -> dict:
 class YoutubeDownloader(Downloader, ABC):
     def __init__(self):
         super().__init__()
-        # YouTube Cookie（docs/05 #34）：经 setup ③「平台 Cookie」填 youtube；
+        # YouTube Cookie（docs/05 #34）：经 setup ③「平台 Cookie」填 youtube，
+        # 或 `videonote cookie from-browser youtube <browser>` 直接读浏览器登录态；
         # 高清/年龄限制/地区限制视频需要登录态，匿名时照常降级
         self._cookie_mgr = CookieConfigManager()
         self._cookie = self._cookie_mgr.get('youtube')
+        self._browser = self._cookie_mgr.get_browser('youtube')
         self._cookiefile = self._write_netscape_cookie_file()
 
     def _write_netscape_cookie_file(self) -> Optional[str]:
@@ -97,7 +99,11 @@ class YoutubeDownloader(Downloader, ABC):
             'quiet': False,
             'progress_hooks': [ytdlp_cancel_hook(cancel_event)],
         }
-        if self._cookiefile:
+        if self._browser:
+            # cookiesfrombrowser 优先：直接读浏览器登录态（`videonote cookie from-browser`），
+            # 无需手动导出 cookie 字符串；读取失败由 yt-dlp 报错并降级
+            ydl_opts['cookiesfrombrowser'] = (self._browser,)
+        elif self._cookiefile:
             ydl_opts['cookiefile'] = self._cookiefile
 
         if skip_download:
@@ -161,7 +167,11 @@ class YoutubeDownloader(Downloader, ABC):
             'merge_output_format': 'mp4',  # 确保合并成 mp4
             'progress_hooks': [ytdlp_cancel_hook(cancel_event)],
         }
-        if self._cookiefile:
+        if self._browser:
+            # cookiesfrombrowser 优先：直接读浏览器登录态（`videonote cookie from-browser`），
+            # 无需手动导出 cookie 字符串；读取失败由 yt-dlp 报错并降级
+            ydl_opts['cookiesfrombrowser'] = (self._browser,)
+        elif self._cookiefile:
             ydl_opts['cookiefile'] = self._cookiefile
 
         _apply_proxy(ydl_opts)

--- a/app/services/cookie_manager.py
+++ b/app/services/cookie_manager.py
@@ -40,10 +40,33 @@ class CookieConfigManager:
                 return val.get("cookie")
             return val if isinstance(val, str) else None
 
+    def get_browser(self, platform: str) -> Optional[str]:
+        """已配置的 cookiesfrombrowser 来源（safari/chrome/...）；None 未配置。"""
+        with self._lock:
+            val = self._read().get(platform)
+            if isinstance(val, dict):
+                return val.get("browser") or None
+            return None
+
     def set(self, platform: str, cookie: str):
         with self._lock:
             data = self._read()
+            # 保留已配置的 browser（set_browser 与 set 互不覆盖，#C2）
+            browser = data[platform].get("browser") if isinstance(data.get(platform), dict) else None
             data[platform] = {"cookie": cookie}
+            if browser:
+                data[platform]["browser"] = browser
+            self._write(data)
+
+    def set_browser(self, platform: str, browser: str):
+        """配置 cookiesfrombrowser 来源；保留已存的手动 cookie（下载器优先用 browser）。"""
+        with self._lock:
+            data = self._read()
+            entry = data.get(platform)
+            if not isinstance(entry, dict):
+                entry = {"cookie": entry if isinstance(entry, str) else ""}
+            entry["browser"] = browser
+            data[platform] = entry
             self._write(data)
 
     def delete(self, platform: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote"
-version = "0.1.10"
+version = "0.1.11"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -177,6 +177,43 @@ class TestTranscriberCli:
         assert "说话人分离: 关" in _cli_out(capsys)
 
 
+class TestProxyCli:
+    def test_set_and_list(self, capsys):
+        cli._proxy_cli(["set", "http://127.0.0.1:7897"])
+        assert "代理已启用: http://127.0.0.1:7897" in _cli_out(capsys)
+        capsys.readouterr()
+        cli._proxy_cli(["list"])
+        out = _cli_out(capsys)
+        assert "http://127.0.0.1:7897" in out
+        assert "配置文件启用" in out
+
+    def test_list_masks_credentials(self, capsys):
+        # 代理 URL 可带 user:pass@：list 只留 host，不落凭据（与 _apply_proxy 日志同口径）
+        cli._proxy_cli(["set", "http://user:secret@127.0.0.1:7897"])
+        capsys.readouterr()
+        cli._proxy_cli(["list"])
+        out = _cli_out(capsys)
+        assert "user:secret" not in out
+        assert "http://127.0.0.1:7897" in out
+
+    def test_off_falls_back_to_env(self, capsys, monkeypatch):
+        cli._proxy_cli(["set", "http://127.0.0.1:7897"])
+        capsys.readouterr()
+        cli._proxy_cli(["off"])
+        assert "代理已关闭" in _cli_out(capsys)
+        monkeypatch.setenv("HTTPS_PROXY", "http://10.0.0.1:8080")
+        capsys.readouterr()
+        cli._proxy_cli(["list"])
+        out = _cli_out(capsys)
+        assert "http://10.0.0.1:8080" in out
+        assert "环境变量" in out
+
+    def test_set_missing_url(self):
+        with pytest.raises(SystemExit) as ei:
+            cli._proxy_cli(["set"])
+        assert ei.value.code == 2
+
+
 class TestExportCli:
     def test_export_list_formats(self, capsys):
         cli._export_cli(["list"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -214,6 +214,55 @@ class TestProxyCli:
         assert ei.value.code == 2
 
 
+class TestCookieCli:
+    def test_set_and_list_masks_value(self, capsys):
+        cli._cookie_cli(["set", "youtube", "SID=abc; LOGIN_INFO=xyz"])
+        out = _cli_out(capsys)
+        assert "已保存 youtube 的 Cookie" in out
+        capsys.readouterr()
+        cli._cookie_cli(["list"])
+        out = _cli_out(capsys)
+        assert "youtube" in out
+        assert "已配置" in out
+        assert "abc" not in out  # 不显示明文
+        assert "xyz" not in out
+
+    def test_from_browser_and_list(self, capsys):
+        cli._cookie_cli(["from-browser", "youtube", "safari"])
+        out = _cli_out(capsys)
+        assert "youtube 将直接读取 safari 的登录态" in out
+        capsys.readouterr()
+        cli._cookie_cli(["list"])
+        out = _cli_out(capsys)
+        assert "youtube: 浏览器（safari）" in out
+
+    def test_from_browser_keeps_manual_cookie(self, capsys):
+        # set 与 from-browser 互不覆盖（#C2）
+        cli._cookie_cli(["set", "youtube", "SID=abc"])
+        capsys.readouterr()
+        cli._cookie_cli(["from-browser", "youtube", "chrome"])
+        capsys.readouterr()
+        cli._cookie_cli(["list"])
+        out = _cli_out(capsys)
+        assert "浏览器（chrome）" in out
+        assert "手动 cookie" in out
+
+    def test_clear(self, capsys):
+        cli._cookie_cli(["set", "youtube", "SID=abc"])
+        capsys.readouterr()
+        cli._cookie_cli(["clear", "youtube"])
+        out = _cli_out(capsys)
+        assert "已清除 youtube" in out
+        capsys.readouterr()
+        cli._cookie_cli(["list"])
+        assert "未配置" in _cli_out(capsys)
+
+    def test_invalid_platform(self):
+        with pytest.raises(SystemExit) as ei:
+            cli._cookie_cli(["set", "vimeo", "x=1"])
+        assert ei.value.code == 2
+
+
 class TestExportCli:
     def test_export_list_formats(self, capsys):
         cli._export_cli(["list"])

--- a/tests/test_youtube_downloader.py
+++ b/tests/test_youtube_downloader.py
@@ -1,0 +1,78 @@
+"""YoutubeDownloader 的 Cookie 注入（#C2）：cookiesfrombrowser 优先于手动 cookiefile。
+
+不碰真实网络/yt-dlp：mock CookieConfigManager 与 yt_dlp.YoutubeDL。
+"""
+import sys
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.downloaders.youtube_downloader import YoutubeDownloader
+
+
+class _YdlCtx:
+    def __init__(self, info):
+        self._info = info
+
+    def extract_info(self, *a, **k):
+        return self._info
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _make_dl(cookie=None, browser=None):
+    """构造下载器，cookie/browser 由 mock 的 CookieConfigManager 提供。"""
+    with mock.patch(
+        "app.downloaders.youtube_downloader.CookieConfigManager"
+    ) as m_mgr_cls:
+        m_mgr = m_mgr_cls.return_value
+        m_mgr.get.return_value = cookie
+        m_mgr.get_browser.return_value = browser
+        dl = YoutubeDownloader()
+    return dl, m_mgr
+
+
+def _capture_opts(dl, url="https://www.youtube.com/watch?v=xxxxxx"):
+    captured = {}
+
+    def _fake_ydl(opts):
+        captured.update(opts)
+        return _YdlCtx({"id": "x", "title": "t", "duration": 10, "ext": "m4a"})
+
+    with mock.patch("yt_dlp.YoutubeDL", side_effect=_fake_ydl):
+        dl.download(url, output_dir=tempfile.mkdtemp())
+    return captured
+
+
+class TestCookieInjection:
+    """browser 优先、手动 cookie 次之、无配置时不注入。"""
+
+    def test_browser_config_uses_cookiesfrombrowser(self):
+        dl, _ = _make_dl(cookie=None, browser="safari")
+        opts = _capture_opts(dl)
+        assert opts.get("cookiesfrombrowser") == ("safari",)
+        assert "cookiefile" not in opts
+
+    def test_manual_cookie_uses_cookiefile(self):
+        dl, _ = _make_dl(cookie="SID=abc", browser=None)
+        opts = _capture_opts(dl)
+        assert "cookiesfrombrowser" not in opts
+        assert opts.get("cookiefile") is not None
+
+    def test_browser_wins_over_manual_cookie(self):
+        dl, _ = _make_dl(cookie="SID=abc", browser="chrome")
+        opts = _capture_opts(dl)
+        assert opts.get("cookiesfrombrowser") == ("chrome",)
+        assert "cookiefile" not in opts
+
+    def test_no_cookie_no_injection(self):
+        dl, _ = _make_dl(cookie=None, browser=None)
+        opts = _capture_opts(dl)
+        assert "cookiesfrombrowser" not in opts
+        assert "cookiefile" not in opts

--- a/uv.lock
+++ b/uv.lock
@@ -4021,7 +4021,7 @@ wheels = [
 
 [[package]]
 name = "videonote"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.10"
+__version__ = "0.1.11"

--- a/videonote_mcp/cli.py
+++ b/videonote_mcp/cli.py
@@ -1416,6 +1416,62 @@ def _proxy_cli(argv) -> None:
         print("✅ 代理已关闭（回退环境变量）", file=sys.stdout)
 
 
+_COOKIE_PLATFORMS = ("youtube", "bilibili", "douyin", "kuaishou")
+
+
+def _cookie_cli(argv) -> None:
+    """`videonote cookie ...`：在终端管理平台 Cookie。
+
+    YouTube 等需登录态的视频（高清/年龄限制/地区限制）需要 Cookie：
+    - `from-browser`：直接读 Safari/Chrome 的登录态（yt-dlp cookiesfrombrowser），最省事
+    - `set`：手动粘贴浏览器复制出来的完整 Cookie 字符串
+    B 站推荐 `videonote login bilibili` 扫码登录（AI 字幕需要 SESSDATA）。
+    """
+    parser = argparse.ArgumentParser(
+        prog="videonote cookie",
+        description="平台 Cookie 配置（youtube 等需登录态内容）",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("list", help="查看各平台 Cookie 状态（不显示明文）")
+    p_set = sub.add_parser("set", help="手动粘贴 Cookie 字符串（name=value; ...）")
+    p_set.add_argument("platform", choices=_COOKIE_PLATFORMS)
+    p_set.add_argument("cookie", help="完整 Cookie 字符串")
+    p_fb = sub.add_parser("from-browser", help="直接读浏览器登录态（无需手动导出）")
+    p_fb.add_argument("platform", choices=_COOKIE_PLATFORMS)
+    p_fb.add_argument("browser", choices=("safari", "chrome", "edge", "firefox"), help="从哪个浏览器读登录态")
+    p_clear = sub.add_parser("clear", help="清除某平台的 Cookie 配置")
+    p_clear.add_argument("platform", choices=_COOKIE_PLATFORMS)
+
+    opts = parser.parse_args(argv)
+    from app.services.cookie_manager import CookieConfigManager
+
+    mgr = CookieConfigManager()
+    if opts.cmd == "list":
+        data = mgr.list_all()
+        if not data:
+            print("平台 Cookie: 未配置", file=sys.stdout)
+            return
+        for platform in sorted(data):
+            cookie = data[platform]
+            browser = mgr.get_browser(platform)
+            if browser:
+                suffix = f" + 手动 cookie（{len(cookie)} 字符）" if cookie else ""
+                print(f"{platform}: 浏览器（{browser}）{suffix}", file=sys.stdout)
+            elif cookie:
+                print(f"{platform}: 已配置（{len(cookie)} 字符，不显示明文）", file=sys.stdout)
+    elif opts.cmd == "set":
+        mgr.set(opts.platform, opts.cookie)
+        print(f"✅ 已保存 {opts.platform} 的 Cookie", file=sys.stdout)
+    elif opts.cmd == "from-browser":
+        mgr.set_browser(opts.platform, opts.browser)
+        print(f"✅ {opts.platform} 将直接读取 {opts.browser} 的登录态", file=sys.stdout)
+        print("  （yt-dlp cookiesfrombrowser；读取失败时自动降级匿名）", file=sys.stdout)
+    elif opts.cmd == "clear":
+        mgr.delete(opts.platform)
+        print(f"✅ 已清除 {opts.platform} 的 Cookie 配置", file=sys.stdout)
+
+
 def _login_cli(argv, exit_on_fail: bool = True) -> None:
     """`videonote login [bilibili]`：扫码登录 B 站，自动获取并保存 SESSDATA（AI 字幕用）。
 
@@ -1667,7 +1723,7 @@ def _export_cli(argv) -> None:
 
 def main() -> None:
     """入口：providers / setup / transcriber / login / export 走轻量 CLI；**无参数**时才是 MCP server（stdio）。"""
-    known = ("providers", "setup", "transcriber", "login", "export", "proxy")
+    known = ("providers", "setup", "transcriber", "login", "export", "proxy", "cookie")
     if len(sys.argv) > 1 and sys.argv[1] in known:
         cmd = sys.argv[1]
         if cmd == "providers":
@@ -1680,6 +1736,8 @@ def main() -> None:
             _export_cli(sys.argv[2:])
         elif cmd == "proxy":
             _proxy_cli(sys.argv[2:])
+        elif cmd == "cookie":
+            _cookie_cli(sys.argv[2:])
         else:
             _transcriber_cli(sys.argv[2:])
         return

--- a/videonote_mcp/cli.py
+++ b/videonote_mcp/cli.py
@@ -48,6 +48,7 @@ from app.db.init_db import init_db
 from app.db.model_dao import get_model_by_provider_and_name, insert_model
 from app.db.provider_dao import seed_default_providers
 from app.services.provider import ProviderService
+from app.services.proxy_config_manager import ProxyConfigManager
 from app.services.transcriber_config_manager import TranscriberConfigManager
 
 init_db()
@@ -1372,6 +1373,49 @@ def _transcriber_cli(argv) -> None:
                 )
 
 
+def _proxy_cli(argv) -> None:
+    """`videonote proxy ...`：在终端管理全局代理。
+
+    作用范围：LLM API + 转写 API（Groq 等）+ yt-dlp 视频下载（youtube/generic 下载器
+    都经 _apply_proxy 透传）。优先级：配置文件 enabled=true 的 url > 环境变量
+    HTTPS_PROXY/HTTP_PROXY/ALL_PROXY。fake-ip 代理（Clash/Surge）环境下不配代理，
+    yt-dlp 会直连解析出的保留段地址而失败。
+    """
+    parser = argparse.ArgumentParser(
+        prog="videonote proxy",
+        description="全局代理配置（LLM/转写/yt-dlp 下载共用；优先于环境变量）",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("list", help="查看当前代理状态与来源")
+    p_set = sub.add_parser("set", help="启用并设置代理 URL（如 http://127.0.0.1:7897）")
+    p_set.add_argument("url", help="代理 URL（http://host:port；可带 user:pass@）")
+    sub.add_parser("off", help="关闭代理（回退环境变量）")
+
+    opts = parser.parse_args(argv)
+    mgr = ProxyConfigManager()
+    if opts.cmd == "list":
+        cfg = mgr.get_config()
+        env = next(
+            (os.environ.get(k) for k in ("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy") if os.environ.get(k)),
+            None,
+        )
+        if cfg["enabled"] and cfg["url"]:
+            from app.utils.url_safety import sanitize_url
+
+            print(f"代理: {sanitize_url(cfg['url'])}（配置文件启用）", file=sys.stdout)
+        elif env:
+            print(f"代理: {env}（环境变量）", file=sys.stdout)
+        else:
+            print("代理: 未配置（yt-dlp 下载直连；fake-ip 代理环境下会失败）", file=sys.stdout)
+    elif opts.cmd == "set":
+        mgr.update_config(True, opts.url)
+        print(f"✅ 代理已启用: {opts.url}", file=sys.stdout)
+    elif opts.cmd == "off":
+        mgr.update_config(False)
+        print("✅ 代理已关闭（回退环境变量）", file=sys.stdout)
+
+
 def _login_cli(argv, exit_on_fail: bool = True) -> None:
     """`videonote login [bilibili]`：扫码登录 B 站，自动获取并保存 SESSDATA（AI 字幕用）。
 
@@ -1623,7 +1667,7 @@ def _export_cli(argv) -> None:
 
 def main() -> None:
     """入口：providers / setup / transcriber / login / export 走轻量 CLI；**无参数**时才是 MCP server（stdio）。"""
-    known = ("providers", "setup", "transcriber", "login", "export")
+    known = ("providers", "setup", "transcriber", "login", "export", "proxy")
     if len(sys.argv) > 1 and sys.argv[1] in known:
         cmd = sys.argv[1]
         if cmd == "providers":
@@ -1634,6 +1678,8 @@ def main() -> None:
             _login_cli(sys.argv[2:])
         elif cmd == "export":
             _export_cli(sys.argv[2:])
+        elif cmd == "proxy":
+            _proxy_cli(sys.argv[2:])
         else:
             _transcriber_cli(sys.argv[2:])
         return


### PR DESCRIPTION
## proxy 子命令

`videonote proxy list/set <url>/off` —— 全局代理配置（LLM/转写/yt-dlp 下载共用，优先于环境变量）。fake-ip 代理环境下 yt-dlp 下载必需。

## cookie 子命令

`videonote cookie list/set/from-browser/clear` —— 平台 Cookie 配置：
- `from-browser <platform> <browser>`：直接读 Safari/Chrome 登录态（yt-dlp cookiesfrombrowser），**零手动导出**——YouTube 配 cookie 最省事的方式
- `set`：手动粘贴（原 setup 向导入口独立出来）
- 下载器 cookiesfrombrowser 优先于手动 cookie，set 与 from-browser 互不覆盖

## 测试

+9（proxy 4 + cookie 5 + youtube 下载器注入 4 新增中 `test_youtube_downloader.py` 的 4 个）。684 passed + ruff F/I clean