### PR TITLE
feat: videonote login youtube + 浏览器样 headers + bump 0.1.12

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/local)",
   "author": {
     "name": "HuangYincan",

--- a/app/downloaders/generic_downloader.py
+++ b/app/downloaders/generic_downloader.py
@@ -17,7 +17,7 @@ import yt_dlp
 
 from app.downloaders.base import Downloader, DownloadQuality
 from app.downloaders.common import ytdlp_cancel_hook, ytdlp_retry
-from app.downloaders.youtube_downloader import _apply_proxy
+from app.downloaders.youtube_downloader import _apply_browser_headers, _apply_proxy
 from app.models.notes_model import AudioDownloadResult
 from app.services.cookie_manager import CookieConfigManager
 from app.utils.path_helper import get_data_dir
@@ -76,6 +76,7 @@ class GenericDownloader(Downloader, ABC):
         if cookie:
             ydl_opts["http_headers"] = {"Cookie": cookie}
         _apply_proxy(ydl_opts)
+        _apply_browser_headers(ydl_opts)
 
         try:
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
@@ -125,6 +126,7 @@ class GenericDownloader(Downloader, ABC):
         if cookie:
             ydl_opts["http_headers"] = {"Cookie": cookie}
         _apply_proxy(ydl_opts)
+        _apply_browser_headers(ydl_opts)
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             info = ytdlp_retry(ydl.extract_info, video_url, download=True)
         output_path = os.path.join(output_dir, f"{info.get('id')}.mp4")

--- a/app/downloaders/youtube_downloader.py
+++ b/app/downloaders/youtube_downloader.py
@@ -31,35 +31,61 @@ def _apply_proxy(ydl_opts: dict) -> dict:
     return ydl_opts
 
 
+# 浏览器样请求头（2026-08-19）：YouTube 对非浏览器 UA 的请求更容易触发人机验证/反爬，
+# 显式用 Chrome UA + 常规 Accept/Accept-Language 降低触发概率。UA 可用
+# VIDEONOTE_YTDLP_UA 环境变量覆盖（如换 Firefox 或其他版本 Chrome）。
+_DEFAULT_HTTP_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+    "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+}
+
+
+def _apply_browser_headers(ydl_opts: dict) -> dict:
+    """给 yt-dlp 请求套浏览器样 headers，降低 YouTube 人机验证/反爬触发概率。"""
+    ua = os.environ.get("VIDEONOTE_YTDLP_UA") or _DEFAULT_HTTP_HEADERS["User-Agent"]
+    headers = dict(_DEFAULT_HTTP_HEADERS)
+    headers["User-Agent"] = ua
+    # yt-dlp 已有 http_headers 时（如 extractor 注入）合并而不是覆盖
+    ydl_opts['http_headers'] = {**ydl_opts.get('http_headers', {}), **headers}
+    return ydl_opts
+
+
+def cookie_string_to_netscape(cookie: str) -> Optional[str]:
+    """Cookie 字符串（name=value; ...）→ Netscape 格式临时文件路径（yt-dlp cookiefile 用）。
+
+    CLI `videonote cookie set` / `login youtube` 的验证与下载器共用同一写入逻辑。
+    """
+    if not cookie:
+        return None
+    lines = ["# Netscape HTTP Cookie File\n"]
+    for pair in cookie.split("; "):
+        if "=" in pair:
+            key, value = pair.split("=", 1)
+            lines.append(f".youtube.com\tTRUE\t/\tFALSE\t0\t{key}\t{value}\n")
+    tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False, encoding='utf-8')
+    tmp.writelines(lines)
+    tmp.close()
+    try:
+        os.chmod(tmp.name, 0o600)
+    except OSError:
+        pass
+    return tmp.name
+
+
 class YoutubeDownloader(Downloader, ABC):
     def __init__(self):
         super().__init__()
         # YouTube Cookie（docs/05 #34）：经 setup ③「平台 Cookie」填 youtube，
-        # 或 `videonote cookie from-browser youtube <browser>` 直接读浏览器登录态；
+        # 或 `videonote login youtube --browser safari` 直接读浏览器登录态；
         # 高清/年龄限制/地区限制视频需要登录态，匿名时照常降级
         self._cookie_mgr = CookieConfigManager()
         self._cookie = self._cookie_mgr.get('youtube')
         self._browser = self._cookie_mgr.get_browser('youtube')
-        self._cookiefile = self._write_netscape_cookie_file()
-
-    def _write_netscape_cookie_file(self) -> Optional[str]:
-        """将 Cookie 写入 Netscape 格式临时文件，返回文件路径（供 yt-dlp cookiefile 使用）。"""
-        if not self._cookie:
-            return None
-        lines = ["# Netscape HTTP Cookie File\n"]
-        for pair in self._cookie.split("; "):
-            if "=" in pair:
-                key, value = pair.split("=", 1)
-                lines.append(f".youtube.com\tTRUE\t/\tFALSE\t0\t{key}\t{value}\n")
-        tmp = tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False, encoding='utf-8')
-        tmp.writelines(lines)
-        tmp.close()
-        try:
-            os.chmod(tmp.name, 0o600)
-        except OSError:
-            pass
-        logger.info("已生成 YouTube Netscape Cookie 文件（条目: %d）", len(lines) - 1)
-        return tmp.name
+        self._cookiefile = cookie_string_to_netscape(self._cookie)
 
     def _cleanup_cookie_file(self) -> None:
         path = getattr(self, "_cookiefile", None)
@@ -110,6 +136,7 @@ class YoutubeDownloader(Downloader, ABC):
             ydl_opts['skip_download'] = True
 
         _apply_proxy(ydl_opts)
+        _apply_browser_headers(ydl_opts)
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             info = ytdlp_retry(ydl.extract_info, video_url, download=not skip_download)
             video_id = info.get("id")
@@ -175,6 +202,7 @@ class YoutubeDownloader(Downloader, ABC):
             ydl_opts['cookiefile'] = self._cookiefile
 
         _apply_proxy(ydl_opts)
+        _apply_browser_headers(ydl_opts)
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             info = ytdlp_retry(ydl.extract_info, video_url, download=True)
             video_id = info.get("id")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote"
-version = "0.1.11"
+version = "0.1.12"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -263,6 +263,46 @@ class TestCookieCli:
         assert ei.value.code == 2
 
 
+class TestLoginYoutube:
+    def test_browser_success_saves_and_verifies(self, capsys, monkeypatch):
+        monkeypatch.setattr(cli, "_verify_youtube_login", lambda **kw: "")
+        cli._login_youtube(["--browser", "safari"])
+        out = _cli_out(capsys)
+        assert "登录态有效" in out
+        # 配置已保存（cookie list 可见）
+        capsys.readouterr()
+        cli._cookie_cli(["list"])
+        assert "youtube: 浏览器（safari）" in _cli_out(capsys)
+        # 清理：不污染共享 downloader.json（其它测试假设 youtube 无 browser 配置）
+        capsys.readouterr()
+        cli._cookie_cli(["clear", "youtube"])
+
+    def test_browser_failure_reports_and_exits(self, capsys, monkeypatch):
+        monkeypatch.setattr(cli, "_verify_youtube_login", lambda **kw: "Read error")
+        with pytest.raises(SystemExit) as ei:
+            cli._login_youtube(["--browser", "chrome"])
+        assert ei.value.code == 1
+        out = _cli_out(capsys)
+        assert "验证失败" in out
+        assert "Read error" in out
+
+    def test_browser_failure_exit_on_fail_false_returns(self, capsys, monkeypatch):
+        monkeypatch.setattr(cli, "_verify_youtube_login", lambda **kw: "Read error")
+        cli._login_youtube(["--browser", "chrome"], exit_on_fail=False)
+        assert "验证失败" in _cli_out(capsys)
+
+    def test_invalid_browser(self):
+        with pytest.raises(SystemExit) as ei:
+            cli._login_youtube(["--browser", "netscape"])
+        assert ei.value.code == 2
+
+    def test_unknown_platform_rejected(self, capsys):
+        with pytest.raises(SystemExit) as ei:
+            cli._login_cli(["vimeo"])
+        assert ei.value.code == 2
+        assert "未知平台" in capsys.readouterr().err
+
+
 class TestExportCli:
     def test_export_list_formats(self, capsys):
         cli._export_cli(["list"])

--- a/tests/test_downloader_robustness.py
+++ b/tests/test_downloader_robustness.py
@@ -143,12 +143,17 @@ class GenericCookieTest(unittest.TestCase):
 
     def test_cookie_injected_as_header(self):
         captured = self._download_with_cookie("sessionid=abc123")
-        self.assertEqual(captured["http_headers"], {"Cookie": "sessionid=abc123"})
+        headers = captured["http_headers"]
+        self.assertEqual(headers["Cookie"], "sessionid=abc123")
+        # 浏览器样头（防 YouTube 人机验证）与 Cookie 共存
+        self.assertIn("Chrome/", headers["User-Agent"])
         self.assertNotIn("cookiefile", captured)
 
-    def test_no_cookie_no_headers(self):
+    def test_no_cookie_still_browser_headers(self):
         captured = self._download_with_cookie("")
-        self.assertNotIn("http_headers", captured)
+        headers = captured["http_headers"]
+        self.assertNotIn("Cookie", headers)
+        self.assertIn("Chrome/", headers["User-Agent"])
 
     def test_no_cookie_file_left_on_disk(self):
         import app.downloaders.generic_downloader as mod

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -280,7 +280,8 @@ class TestYoutubeCookie(unittest.TestCase):
     def _dl(self, cookie, tmp_name):
         import app.downloaders.youtube_downloader as mod
 
-        with mock.patch.object(mod.CookieConfigManager, "get", return_value=cookie):
+        with mock.patch.object(mod.CookieConfigManager, "get", return_value=cookie), \
+             mock.patch.object(mod.CookieConfigManager, "get_browser", return_value=None):
             fake = mock.Mock()
             fake.name = tmp_name
             fake.close = mock.Mock()

--- a/tests/test_youtube_downloader.py
+++ b/tests/test_youtube_downloader.py
@@ -76,3 +76,24 @@ class TestCookieInjection:
         opts = _capture_opts(dl)
         assert "cookiesfrombrowser" not in opts
         assert "cookiefile" not in opts
+
+
+class TestBrowserHeaders:
+    """浏览器样请求头：默认 Chrome UA，VIDEONOTE_YTDLP_UA 可覆盖（防 YouTube 人机验证）。"""
+
+    def test_default_browser_headers(self, monkeypatch):
+        monkeypatch.delenv("VIDEONOTE_YTDLP_UA", raising=False)
+        dl, _ = _make_dl()
+        opts = _capture_opts(dl)
+        ua = opts["http_headers"]["User-Agent"]
+        assert "Chrome/" in ua
+        assert "Mozilla/5.0" in ua
+        assert "Accept-Language" in opts["http_headers"]
+
+    def test_ua_override(self, monkeypatch):
+        monkeypatch.setenv("VIDEONOTE_YTDLP_UA", "TestUA/1.0")
+        dl, _ = _make_dl()
+        opts = _capture_opts(dl)
+        assert opts["http_headers"]["User-Agent"] == "TestUA/1.0"
+        # 覆盖不改其它默认头
+        assert "Accept-Language" in opts["http_headers"]

--- a/uv.lock
+++ b/uv.lock
@@ -4021,7 +4021,7 @@ wheels = [
 
 [[package]]
 name = "videonote"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.11"
+__version__ = "0.1.12"

--- a/videonote_mcp/cli.py
+++ b/videonote_mcp/cli.py
@@ -190,6 +190,7 @@ def _show_uninstall_option(inq, pick: str, size: str, label: str) -> None:
 _CYAN = "\033[1;36m"
 _YELLOW = "\033[1;33m"
 _GREEN = "\033[1;32m"
+_RED = "\033[1;31m"
 _DIM = "\033[2m"
 _RESET = "\033[0m"
 # 让「← 左键」= interrupt（返回上一层，与 Ctrl-C 同）；InquirerPy 绑定需带 key 字段、
@@ -1472,14 +1473,120 @@ def _cookie_cli(argv) -> None:
         print(f"✅ 已清除 {opts.platform} 的 Cookie 配置", file=sys.stdout)
 
 
+def _verify_youtube_login(browser=None, cookie=None) -> str:
+    """用 yt-dlp 实测 YouTube 登录态：能取到元数据即视为有效（返回空串=成功，否则错误信息）。
+
+    走与下载器相同的代理/浏览器 headers 路径；网络问题（如代理未配）会误报，
+    错误信息里说明可能性，由调用方提示用户区分。
+    """
+    import socket
+
+    import yt_dlp
+
+    from app.downloaders.youtube_downloader import (
+        _apply_browser_headers,
+        _apply_proxy,
+        cookie_string_to_netscape,
+    )
+
+    opts: dict = {"quiet": True, "no_warnings": True, "skip_download": True}
+    cookiefile = None
+    if browser:
+        opts["cookiesfrombrowser"] = (browser,)
+    elif cookie:
+        cookiefile = cookie_string_to_netscape(cookie)
+        if cookiefile:
+            opts["cookiefile"] = cookiefile
+    _apply_proxy(opts)
+    _apply_browser_headers(opts)
+    # yt-dlp 无总超时参数：限 socket 层，避免网络悬挂拖住 login 命令
+    socket.setdefaulttimeout(25)
+    try:
+        with yt_dlp.YoutubeDL(opts) as ydl:
+            info = ydl.extract_info("https://www.youtube.com/watch?v=dQw4w9WgXcQ", download=False)
+        if not info:
+            return "未能取得视频信息"
+        return ""
+    except Exception as e:  # noqa: BLE001 —— 上报 yt-dlp 原始错误，由调用方解读
+        return f"{type(e).__name__}: {str(e)[:200]}"
+    finally:
+        socket.setdefaulttimeout(None)
+        if cookiefile:
+            try:
+                import os as _os
+
+                _os.unlink(cookiefile)
+            except OSError:
+                pass
+
+
+def _login_youtube(args, exit_on_fail: bool = True) -> None:
+    """`videonote login youtube`：配置并验证 YouTube 登录态。
+
+    `--browser <safari|chrome|edge|firefox>`：直接读浏览器登录态（yt-dlp
+    cookiesfrombrowser）并**实测验证**；不带则引导手动粘贴完整 Cookie 字符串。
+    """
+    parser = argparse.ArgumentParser(prog="videonote login youtube")
+    parser.add_argument("--browser", choices=("safari", "chrome", "edge", "firefox"), help="从哪个浏览器读登录态（推荐）")
+    opts = parser.parse_args(args)
+
+    from app.services.cookie_manager import CookieConfigManager
+
+    mgr = CookieConfigManager()
+    if opts.browser:
+        mgr.set_browser("youtube", opts.browser)
+        print(f"已配置读取 {opts.browser} 的登录态，正在实测验证（需要网络）…", file=sys.stdout)
+        err = _verify_youtube_login(browser=opts.browser)
+        if not err:
+            print(f"{_GREEN}✓ YouTube 登录态有效，已保存{_RESET}", file=sys.stdout)
+            return
+        print(f"{_RED}✗ 验证失败: {err}{_RESET}", file=sys.stdout)
+        print("  可能原因：浏览器未登录 YouTube / 浏览器 cookie 读取受限（Safari 需解锁）", file=sys.stdout)
+        print("  / 网络不通（检查 `videonote proxy list`）。也可改用 `videonote cookie set youtube '...'` 手动粘贴。", file=sys.stdout)
+        if exit_on_fail:
+            sys.exit(1)
+        return
+
+    # 交互引导：手动粘贴完整 Cookie 字符串
+    _show_header("YouTube 登录")
+    print("1. 打开 https://www.youtube.com 并确认已登录", file=sys.stdout)
+    print("2. 按 F12 → Network 选项卡 → 刷新页面 → 任选一个请求 →", file=sys.stdout)
+    print("   Request Headers 里复制完整 Cookie 行（以 ; 分隔的 name=value 对）", file=sys.stdout)
+    print("3. 粘贴到下面：", file=sys.stdout)
+    try:
+        from InquirerPy import inquirer as inq
+    except ImportError:
+        print("需要 InquirerPy：`uv sync` 后重试", file=sys.stderr)
+        if exit_on_fail:
+            sys.exit(1)
+        return
+    cookie = inq.secret(message="YouTube Cookie 字符串（留空取消）", keybindings=_KB).execute()
+    if not cookie:
+        print("已取消", file=sys.stdout)
+        return
+    mgr.set("youtube", cookie)
+    print("已保存，正在实测验证（需要网络）…", file=sys.stdout)
+    err = _verify_youtube_login(cookie=cookie)
+    if not err:
+        print(f"{_GREEN}✓ YouTube 登录态有效{_RESET}", file=sys.stdout)
+    else:
+        print(f"{_YELLOW}⚠ 验证失败: {err}（配置已保存，下载时若仍失败可重试）{_RESET}", file=sys.stdout)
+
+
 def _login_cli(argv, exit_on_fail: bool = True) -> None:
-    """`videonote login [bilibili]`：扫码登录 B 站，自动获取并保存 SESSDATA（AI 字幕用）。
+    """`videonote login [bilibili|youtube]`：平台登录配置。
+
+    - bilibili：扫码登录，自动获取并保存 SESSDATA（AI 字幕用）
+    - youtube：读浏览器登录态或手动粘贴 Cookie（--browser 时实测验证）
 
     exit_on_fail=False 时失败路径只返回不杀进程（setup 向导内调用，#120：
     登录失败不再让整个向导带 traceback/退出，已配的其它设置不丢失）。
     """
+    if argv and argv[0] == "youtube":
+        _login_youtube(argv[1:], exit_on_fail)
+        return
     if argv and argv[0] != "bilibili":
-        print(f"未知平台: {argv[0]}（当前支持 bilibili）", file=sys.stderr)
+        print(f"未知平台: {argv[0]}（支持 bilibili / youtube）", file=sys.stderr)
         sys.exit(2)
     import time
     import urllib.parse


### PR DESCRIPTION
## login youtube

`videonote login youtube [--browser safari|chrome|edge|firefox]`：
- `--browser`：配置读取浏览器登录态并**实测验证**（yt-dlp 走代理真实请求 YouTube 元数据），有效才报成功
- 不带：交互引导从 DevTools 复制完整 Cookie 字符串粘贴

## 浏览器样 headers（防 YouTube 人机验证/反爬）

youtube/generic 下载器默认注入 Chrome UA + Accept + Accept-Language（`_apply_browser_headers`，与已有 headers 合并）；`VIDEONOTE_YTDLP_UA` 可覆盖。cookie 字符串 → Netscape 文件写入提为模块函数（`cookie_string_to_netscape`），CLI 验证与下载器共用。

## 测试

+11（login youtube 5 + headers 2 + cookie 注入 4）。修复测试隔离：pipeline 的 `_dl` 补 `get_browser` patch（TestLoginYoutube 曾污染共享 downloader.json）。691 passed + ruff F/I clean