### PR TITLE
fix(ytdlp): YouTube JS challenge 硬性配置（EJS + node）+ bump 0.1.13

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/local)",
   "author": {
     "name": "HuangYincan",

--- a/app/downloaders/youtube_downloader.py
+++ b/app/downloaders/youtube_downloader.py
@@ -54,6 +54,20 @@ def _apply_browser_headers(ydl_opts: dict) -> dict:
     return ydl_opts
 
 
+def _apply_js_challenge(ydl_opts: dict) -> dict:
+    """YouTube 2026+ 的 JS challenge（签名/n 求解）硬性要求（2026-08-19 实测）：
+
+    - EJS 远程组件：yt-dlp 默认**不下载** challenge solver 脚本，须显式允许
+      `ejs:github`，否则报「The page needs to be reloaded」；
+    - node runtime：自动检测在 uvx 隔离环境下不可靠（node 在 PATH 也找不到），
+      显式指定 `{'node': {}}` 才生效。
+    缺任一条件，即使有登录 cookie + 代理也会失败。
+    """
+    ydl_opts['remote_components'] = ['ejs:github']
+    ydl_opts['js_runtimes'] = {'node': {}}
+    return ydl_opts
+
+
 def cookie_string_to_netscape(cookie: str) -> Optional[str]:
     """Cookie 字符串（name=value; ...）→ Netscape 格式临时文件路径（yt-dlp cookiefile 用）。
 
@@ -137,6 +151,7 @@ class YoutubeDownloader(Downloader, ABC):
 
         _apply_proxy(ydl_opts)
         _apply_browser_headers(ydl_opts)
+        _apply_js_challenge(ydl_opts)
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             info = ytdlp_retry(ydl.extract_info, video_url, download=not skip_download)
             video_id = info.get("id")
@@ -203,6 +218,7 @@ class YoutubeDownloader(Downloader, ABC):
 
         _apply_proxy(ydl_opts)
         _apply_browser_headers(ydl_opts)
+        _apply_js_challenge(ydl_opts)
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             info = ytdlp_retry(ydl.extract_info, video_url, download=True)
             video_id = info.get("id")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote"
-version = "0.1.12"
+version = "0.1.13"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/tests/test_youtube_downloader.py
+++ b/tests/test_youtube_downloader.py
@@ -78,6 +78,16 @@ class TestCookieInjection:
         assert "cookiefile" not in opts
 
 
+class TestJsChallengeOpts:
+    """YouTube JS challenge 硬性配置：EJS 远程组件 + node runtime（缺则 reloaded 错误）。"""
+
+    def test_ejs_and_node_injected(self):
+        dl, _ = _make_dl()
+        opts = _capture_opts(dl)
+        assert opts["remote_components"] == ["ejs:github"]
+        assert opts["js_runtimes"] == {"node": {}}
+
+
 class TestBrowserHeaders:
     """浏览器样请求头：默认 Chrome UA，VIDEONOTE_YTDLP_UA 可覆盖（防 YouTube 人机验证）。"""
 

--- a/uv.lock
+++ b/uv.lock
@@ -4021,7 +4021,7 @@ wheels = [
 
 [[package]]
 name = "videonote"
-version = "0.1.12"
+version = "0.1.13"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.12"
+__version__ = "0.1.13"

--- a/videonote_mcp/cli.py
+++ b/videonote_mcp/cli.py
@@ -1485,6 +1485,7 @@ def _verify_youtube_login(browser=None, cookie=None) -> str:
 
     from app.downloaders.youtube_downloader import (
         _apply_browser_headers,
+        _apply_js_challenge,
         _apply_proxy,
         cookie_string_to_netscape,
     )
@@ -1499,6 +1500,7 @@ def _verify_youtube_login(browser=None, cookie=None) -> str:
             opts["cookiefile"] = cookiefile
     _apply_proxy(opts)
     _apply_browser_headers(opts)
+    _apply_js_challenge(opts)
     # yt-dlp 无总超时参数：限 socket 层，避免网络悬挂拖住 login 命令
     socket.setdefaulttimeout(25)
     try:


### PR DESCRIPTION
## 根因（实测复现）

yt-dlp 2026 新版解 YouTube JS challenge（签名/n）需要两个显式配置，缺任一即「The page needs to be reloaded」：

1. **EJS 远程组件**：默认不下载 challenge solver 脚本，须 `remote_components: ['ejs:github']`
2. **node runtime**：自动检测在 uvx 隔离环境不可靠（node 在 PATH 也找不到），须显式 `js_runtimes: {'node': {}}`

即使有登录 cookie + 代理也会失败（`videonote login youtube --browser edge` 用户实测）。

## 修复

- `_apply_js_challenge`：youtube 下载器两处 + login 验证注入
- 实测：项目下载器路径 `[jsc:node] Solving JS challenges using node` → 元数据获取成功，无 warning

## 测试

+1（remote_components/js_runtimes 注入断言）。692 passed + ruff F/I clean