### PR TITLE
feat(#C3): 字幕优先机制显性化 + bump 0.1.14

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/local)",
   "author": {
     "name": "HuangYincan",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote"
-version = "0.1.13"
+version = "0.1.14"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/skills/videonote/SKILL.md
+++ b/skills/videonote/SKILL.md
@@ -18,6 +18,7 @@ description: 用 VideoNote-Mcp 的 MCP 工具把视频链接/本地视频（B站
      要全出笔记 → 一条 `batch_generate_notes(url)` 服务端逐个排队（省去逐条 subagent，见规则 2）。
 5. 长视频 / 首次使用 / 最近改过转写引擎 → `preflight(url)` 体检（ffmpeg/磁盘/转写器/供应商 key，`ok=false` 先修）。
 6. 直接 `generate_note(video_url)`（`provider_id` 可省略）。参数不传 = setup / userConfig 默认。
+   - **转写素材自动优先平台官方字幕**（YouTube/B 站人工+自动字幕）——有官方字幕的视频不会走本地转写引擎；无字幕/获取失败才下载音轨转写。用户问「为什么走/没走转写引擎」先看该视频有无官方字幕。
 7. **`get_task_status` 轮询**到 SUCCESS / FAILED / CANCELLED。等待中可用 `stage` / `elapsed_secs` 报进度（如「转写中，已 3 分钟」）。
 8. 呈现 `result.markdown`（要点 + 章节 + 原文链接）。用户要细节再用 `get_task_transcript`（默认前 50 段；全文 `"all"`）。
 9. **不要主动问「要不要后续优化」**。用户要精修再读笔记 + 转写改。

--- a/skills/videonote/reference/tools.md
+++ b/skills/videonote/reference/tools.md
@@ -129,7 +129,8 @@
 
 ## 配置（只读）
 
-- `get_config(provider_id?)` —— **唯一**配置工具（只读）：`app_config` 默认值（默认供应商/模型、风格、开关，敏感项过滤）+ `providers`（key 掩码）+ `transcriber`（引擎/尺寸/就绪）+ `cookie_configured`（已配 Cookie 的平台名）。传 `provider_id` 附加该供应商连通性探测（用已存 key，不接受 key 参数）→ `{probe: {ok, models, error}}`。
+- `get_config(provider_id?)` —— **唯一**配置工具（只读）：`app_config` 默认值（默认供应商/模型、风格、开关，敏感项过滤）+ `providers`（key 掩码）+ `transcriber`（引擎/尺寸/就绪）+ `cookie_configured`（已配 Cookie 的平台名）+ `transcript_source`（固定 `platform_subtitles_first`：平台官方字幕优先，无字幕才转写引擎）。传 `provider_id` 附加该供应商连通性探测（用已存 key，不接受 key 参数）→ `{probe: {ok, models, error}}`。
+- **转写素材来源（自动，无需配置）**：`generate_note` / `prepare_note_material` / `batch_generate_notes` 都优先用平台官方字幕（YouTube/B 站人工+自动字幕，YouTube 走 youtube-transcript-api 自动抓取；有官方字幕就不下载音轨、不耗转写引擎）；无字幕或获取失败才下载音频走转写引擎（fast-whisper/groq/funasr 等）。因此「YouTube 有官方字幕」≠「需要转写引擎」——除非视频无字幕。
 - **配置修改一律走 CLI**（MCP 面无写配置工具，凭证红线最干净）：
   - 填 key：`! videonote providers set <id> --api-key '...'`（隐藏输入）
   - 新增/删供应商、模型：`! videonote providers add/delete`、`! videonote models ...`

--- a/tests/test_server_contracts.py
+++ b/tests/test_server_contracts.py
@@ -1586,6 +1586,7 @@ class GetConfigTest(unittest.TestCase):
         self.assertEqual(resp["providers"][0]["api_key"], "sk-***")  # key 掩码
         self.assertTrue(resp["transcriber"]["ready"])
         self.assertEqual(resp["cookie_configured"], ["bilibili"])   # 只给平台名
+        self.assertEqual(resp["transcript_source"], "platform_subtitles_first")  # #C3 字幕优先
         self.assertNotIn("probe", resp)
         # cookie 值绝不出现在返回里（凭证红线）
         self.assertNotIn("SESSDATA", json.dumps(resp))

--- a/uv.lock
+++ b/uv.lock
@@ -4021,7 +4021,7 @@ wheels = [
 
 [[package]]
 name = "videonote"
-version = "0.1.13"
+version = "0.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"

--- a/videonote_mcp/server.py
+++ b/videonote_mcp/server.py
@@ -670,6 +670,10 @@ def generate_note(
     - screenshot + format 含 "screenshot": 插入图片，产出便携笔记 note.md + Assets/（相对引用）；不传时用 setup ③ 配置的默认（默认关）；显式传入始终覆盖；
     - notes_dir: 便携笔记的输出目录（可选；缺省 VIDEONOTE_NOTES_DIR 环境变量，再缺省 note_results/{task_id}/；支持 file:// URI）。
 
+    转写素材来源（无需配置，自动优先）：平台官方字幕（YouTube/B 站人工+自动字幕）总是
+    先用——官方字幕准、快、不耗转写引擎；无字幕或获取失败才下载音轨走转写引擎
+    （fast-whisper/groq 等）。因此 YouTube 有官方字幕的视频不会走本地 Whisper。
+
     返回 {task_id, status, platform}。之后用 get_task_status 轮询。SUCCESS 时 result.note_dir 指向 note.md 所在目录（{task_id}/gen/，
     指定 notes_dir 时另有 result.portable_note_dir 指向便携副本）。
 
@@ -830,6 +834,7 @@ def prepare_note_material(
     不需要配置 LLM 供应商/模型。返回 {task_id, status: PENDING, kind: material}。
     之后用 get_task_status 轮询；SUCCESS 时 result 含
     {kind: material, title, transcript, frames, comments_danmaku, video_path, audio_path}。
+    transcript 优先来自平台官方字幕（YouTube/B 站人工+自动字幕），无字幕才走转写引擎。
     需要 AI 生成结构化 Markdown 笔记请用 generate_note。
     """
     if platform is None:
@@ -1698,7 +1703,10 @@ def get_config(provider_id: str = "") -> str:
       导出格式等，已过滤敏感键）；
     - providers: 已配置供应商（api_key 掩码）与默认供应商 id；
     - transcriber: 转写引擎配置与模型就绪状态；
-    - cookie_configured: 已配置 Cookie 的平台名列表（只给布尔状态，不给值）。
+    - cookie_configured: 已配置 Cookie 的平台名列表（只给布尔状态，不给值）；
+    - transcript_source: 转写素材来源（固定 platform_subtitles_first——平台官方字幕优先，
+      YouTube/B 站人工+自动字幕可用时直接用官方字幕，无字幕/获取失败才下载音轨走转写引擎；
+      官方字幕通常比本地 Whisper 更准，且不耗转写引擎资源）。
 
     传 provider_id 时额外对该供应商做连通性探测（用已保存的 key 请求
     /v1/models，15s 超时；**不接受 key 参数**），返回 {probe: {ok, models, error}}。
@@ -1727,6 +1735,9 @@ def get_config(provider_id: str = "") -> str:
             "reason": ready["reason"],
         },
         "cookie_configured": cookie_platforms,
+        # 转写素材来源优先级：平台官方字幕（YouTube/B 站人工+自动字幕）总是优先，
+        # 无字幕/获取失败才下载音轨走转写引擎（#C3 让 Agent 知道有官方字幕可用）。
+        "transcript_source": "platform_subtitles_first",
     }
     if provider_id:
         provider = ProviderService.get_provider_by_id(provider_id)
@@ -1770,7 +1781,8 @@ def batch_generate_notes(
     """对播放列表/合集/分 P 链接批量提交笔记任务（服务端逐个排队，遵守并发门禁）。
 
     参数策略：除 video_url 外全部可选——不传即套 setup ③ 配置的默认
-    （与 generate_note 同款；仅需覆盖时显式传）。
+    （与 generate_note 同款；仅需覆盖时显式传）。每条任务同样优先用平台官方字幕
+    （YouTube/B 站人工+自动字幕），无字幕才走转写引擎。
 
     - video_url: 必填，B 站分 P / YouTube 播放列表等可展开为多集的链接；
     - max_entries: 最多提交条数（默认 10，防 200 集播放列表一次全排；超出截断并标记 truncated）；


### PR DESCRIPTION
## 背景

用户真实案例：YouTube 有官方字幕却走了 fast-whisper 转写，Agent 因工具描述未说明字幕机制而误答「工具不支持字幕」。

**代码层事实**：`note.py` 主链路（缓存 → 平台字幕 → 音频转写）字幕**总是优先**，与转写引擎配置无关；当时走转写的根因是**代理未配置**（youtube-transcript-api 直连失败 → fallback），配好 proxy 后字幕获取正常（实测 en 61段）。

## 改动（不新增工具）

- `get_config` 加 `transcript_source: "platform_subtitles_first"` 字段（Agent 一眼可见字幕优先机制）
- `generate_note` / `prepare_note_material` / `batch_generate_notes` docstring 加「平台官方字幕自动优先，无字幕才走转写引擎」
- SKILL.md 流程 + tools.md 转写章节同步说明

## 测试

+1 断言（transcript_source 字段）。692 passed + ruff F/I clean