### PR TITLE
feat: MCP 启动命令 uvx videonote@latest——每次会话自动取 PyPI 最新（v0.1.16）

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/local)",
   "author": {
     "name": "HuangYincan",
@@ -13,7 +13,7 @@
     "videonote": {
       "command": "uvx",
       "args": [
-        "videonote"
+        "videonote@latest"
       ],
       "env": {
         "VIDEONOTE_DEFAULT_STYLE": "${user_config.default_style}",

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ VideoNote-Mcp 把「视频链接 → 多格式笔记」整条流水线打包成 
 ## 快速开始
 
 ```bash
-# 1) 一条命令装好 Skill + MCP（插件 marketplace，uvx 自动更新）
+# 1) 一条命令装好 Skill + MCP（插件 marketplace；MCP 启动命令 uvx videonote@latest 自动取 PyPI 最新版）
 claude plugin marketplace add HuangYincan/VideoNote-MCP
 claude plugin install videonote@videonote
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -34,7 +34,7 @@ It works **end-to-end (one link → one note)** and is **also decoupled**: pick 
 ## Quick Start
 
 ```bash
-# 1) One command installs both Skill + MCP (plugin marketplace, uvx auto-updates)
+# 1) One command installs both Skill + MCP (plugin marketplace; MCP command `uvx videonote@latest` auto-fetches the latest PyPI release on each session start)
 claude plugin marketplace add HuangYincan/VideoNote-MCP
 claude plugin install videonote@videonote
 

--- a/docs/06-执行进度.md
+++ b/docs/06-执行进度.md
@@ -321,3 +321,4 @@
 - [x] **server.py 四组合并**（commit e02296d）：`task` 收编 get_task_status / get_task_transcript / cancel_note；`cleanup` 收编 cleanup_note / cleanup_all；`process_media` 收编 export_transcript / merge_audio / diarize_media；`health_check` 扩展收编 preflight——不丢功能：分段转写 / dry_run 先查后清 / need_provider / hf_token 蜜罐 / 运行中拒绝全保留。
 - [x] **契约测试迁移 + 新增 test_138_batch.py**（16 tests）：692 + 16 = **708 passed**。
 - [x] **CI 名单更新**：ci.yml 工具名单 16 → 10。
+- [x] **MCP 启动命令 uvx videonote@latest**（v0.1.16）：plugin.json 启动命令改为 `uvx videonote@latest`——每次会话启动自动取 PyPI 最新版，发版即生效（原 `uvx videonote` 走缓存不保证更新）；`_skill_refresh_advice` 文案同步校正；README 中英安装说明同步。708 passed + ruff clean。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote"
-version = "0.1.15"
+version = "0.1.16"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/uv.lock
+++ b/uv.lock
@@ -4021,7 +4021,7 @@ wheels = [
 
 [[package]]
 name = "videonote"
-version = "0.1.15"
+version = "0.1.16"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.15"
+__version__ = "0.1.16"

--- a/videonote_mcp/server.py
+++ b/videonote_mcp/server.py
@@ -1629,7 +1629,8 @@ def health_check(
 def _skill_refresh_advice() -> str:
     """插件/Skill 刷新提示（docs/05 #24）：server 与插件版本不一致时点名提示。"""
     base = (
-        "MCP（uvx）跟 git HEAD；Skill/插件不自动更新。"
+        "MCP（启动命令 uvx videonote@latest）每次会话启动自动取 PyPI 最新版；"
+        "Skill/插件不自动更新。"
         "工作流对不上时：`claude plugin disable videonote@videonote` "
         "然后 `claude plugin install videonote@videonote`，再开新会话。"
     )


### PR DESCRIPTION
MCP 启动命令 `uvx videonote` → `uvx videonote@latest`（uvx 官方推荐的 tool 升级写法，替代 `--upgrade`）：每次会话启动自动解析 PyPI 最新版，发版即生效；断网时影响≈0（工具本身依赖网络）。`_skill_refresh_advice` 文案同步校正（原「MCP 跟 git HEAD」不准确）。708 passed + ruff clean。