### PR TITLE
release: v0.1.17（#32 转写器修复 + #138 工具精简 + uvx @latest）

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/local)",
   "author": {
     "name": "HuangYincan",

--- a/app/services/note.py
+++ b/app/services/note.py
@@ -504,7 +504,6 @@ class NoteGenerator:
             self._update_status(task_id, TaskStatus.FAILED, message=str(exc))
             return None
 
-    @staticmethod
     # ---------------- 私有方法 ----------------
 
     def _init_transcriber(self) -> Transcriber:

--- a/docs/06-执行进度.md
+++ b/docs/06-执行进度.md
@@ -322,3 +322,9 @@
 - [x] **契约测试迁移 + 新增 test_138_batch.py**（16 tests）：692 + 16 = **708 passed**。
 - [x] **CI 名单更新**：ci.yml 工具名单 16 → 10。
 - [x] **MCP 启动命令 uvx videonote@latest**（v0.1.16）：plugin.json 启动命令改为 `uvx videonote@latest`——每次会话启动自动取 PyPI 最新版，发版即生效（原 `uvx videonote` 走缓存不保证更新）；`_skill_refresh_advice` 文案同步校正；README 中英安装说明同步。708 passed + ruff clean。
+
+## 批 28：#32 悬空 @staticmethod 修复（709 tests）
+
+用户报障 issue #32（无字幕视频本地转写 100% 失败）。**709 passed + ruff F/I-clean**（708 + 1）。
+
+- [x] **删除 note.py 悬空 @staticmethod**（commit 75571cb）：#134 死代码清理删 delete_note 时残留装饰器行，注释不打断绑定 → `_init_transcriber` 被误绑静态方法，`self._init_transcriber()` 抛 `missing 1 required positional argument: 'self'`（本地复现确认 + 红绿验证）。回归测试打桩 `get_transcriber` 而非 `_init_transcriber` 本身，强制走 914 行真实调用路径。709 passed + ruff clean。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -719,3 +719,10 @@ v0.1.1 → v0.1.2 的主要变更（详见下方各「维护」节点块；稳�
 - **四组合并 + 扩展**（commit e02296d）：`task` 收编 get_task_status / get_task_transcript / cancel_note；`cleanup` 收编 cleanup_note / cleanup_all；`process_media` 收编 export_transcript / merge_audio / diarize_media；`health_check` 扩展收编 preflight。
 - **不丢功能**：分段转写 / dry_run 先查后清 / need_provider / hf_token 蜜罐 / 运行中拒绝全保留。
 - **708 passed + ruff F/I-clean**（692 + 16：契约测试迁移 + 新增 test_138_batch.py 16 tests）；CI 名单 16 → 10。
+
+## Wave I 批 28（2026-08-24 · #32 转写器实例绑定修复，708→709 tests）
+
+用户报障 issue #32：无官方字幕、需走本地转写的视频 100% 失败。
+
+- **删除 note.py 悬空 @staticmethod**（commit 75571cb）：#134 死代码清理删 `delete_note` 时残留装饰器行，注释不打断绑定 → `_init_transcriber` 被误绑为静态方法，`self._init_transcriber()` 抛 `missing 1 required positional argument: 'self'`（本地复现 + 红绿验证）。回归测试打桩 `get_transcriber` 而非 `_init_transcriber` 本身，强制走 914 行真实绑定路径，防止同类回归再漏网。
+- **709 passed + ruff F/I-clean**（708 + 1）；docs/06 批 28 同步登记。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote"
-version = "0.1.16"
+version = "0.1.17"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/tests/test_note_cache.py
+++ b/tests/test_note_cache.py
@@ -316,12 +316,12 @@ class GenerateIntegrationTest(unittest.TestCase):
         self.cache = note_cache.cache_root()
         shutil.rmtree(self.cache, ignore_errors=True)
         # 清掉可能残留的同名任务目录（per-task 缓存会短路整条流水线）
-        for tid in ("cachehit00001", "cachemiss00001", "media000001", "media000002"):
+        for tid in ("cachehit00001", "cachemiss00001", "media000001", "media000002", "asrregg00001"):
             shutil.rmtree(NOTE_OUTPUT_DIR / tid, ignore_errors=True)
 
     def tearDown(self):
         shutil.rmtree(self.cache, ignore_errors=True)
-        for tid in ("cachehit00001", "cachemiss00001", "media000001", "media000002"):
+        for tid in ("cachehit00001", "cachemiss00001", "media000001", "media000002", "asrregg00001"):
             shutil.rmtree(NOTE_OUTPUT_DIR / tid, ignore_errors=True)
 
     def _gen(self):
@@ -379,6 +379,36 @@ class GenerateIntegrationTest(unittest.TestCase):
         entry = note_cache.cache_root() / "youtube-abcDEF12345" / f"transcript_{key}.json"
         self.assertTrue(entry.exists())
         self.assertEqual(json.loads(entry.read_text(encoding="utf-8"))["full_text"], "fresh")
+
+    def test_real_init_transcriber_binds_as_instance_method(self):
+        """#32：_init_transcriber 曾被悬空 @staticmethod 误绑（#134 死代码清理残留），
+        无字幕走本地转写时 self._init_transcriber() 抛
+        "missing 1 required positional argument: 'self'"。
+        这里打桩 get_transcriber（真实方法体内的调用）而非 _init_transcriber 本身，
+        强制走 914 行真实调用路径，验证实例方法绑定 + 惰性初始化完成。"""
+        gen = self._gen()
+        gen.transcriber_type = "fast-whisper"
+        gen.model_size = "small"
+        fake_transcriber = mock.Mock()
+        downloader = _fake_downloader("abcDEF12345")
+        transcript_dict = {
+            "language": "zh", "full_text": "fresh",
+            "segments": [{"start": 0, "end": 1, "text": "fresh"}],
+        }
+        with mock.patch.object(gen, "_get_downloader", return_value=downloader):
+            with mock.patch("app.services.note.get_transcriber", return_value=fake_transcriber) as gt:
+                with mock.patch.object(
+                    note_pipeline, "fetch_subtitles",
+                    side_effect=AssertionError("不应重复调用字幕 API"),
+                ), mock.patch.object(note_pipeline, "transcribe_audio", return_value=transcript_dict):
+                    result = gen.generate(
+                        video_url=self.YT_URL, platform="youtube",
+                        task_id="asrregg00001", material_only=True,
+                    )
+        # 真实 _init_transcriber 跑通：get_transcriber 收到实例属性，惰性初始化完成
+        gt.assert_called_once_with(transcriber_type="fast-whisper", model_size="small")
+        self.assertIs(gen.transcriber, fake_transcriber)
+        self.assertEqual(result.transcript.full_text, "fresh")
 
     def test_get_transcript_skip_subtitle_avoids_second_fetch(self):
         """_get_transcript(skip_subtitle=True) 直接走转写，不重复调 pipeline.fetch_subtitles。"""

--- a/uv.lock
+++ b/uv.lock
@@ -4021,7 +4021,7 @@ wheels = [
 
 [[package]]
 name = "videonote"
-version = "0.1.16"
+version = "0.1.17"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.16"
+__version__ = "0.1.17"


### PR DESCRIPTION
## 发布内容（8 commits）

1. **fix(#32)**（75571cb）：删除 `app/services/note.py` 悬空 `@staticmethod`——#134 死代码清理残留，`_init_transcriber` 被误绑静态方法，无官方字幕走本地转写的视频 100% 失败（issue #32 复现确认 + 红绿验证）。+1 回归测试（709 tests）。
2. **#138 工具精简 16→10**（e02296d）+ release.yml 冒烟调整（6334da8）+ docs 回填（3035c08）。
3. **MCP 启动命令改 uvx videonote@latest**（7161aad）：每次会话自动取 PyPI 最新版。
4. README 精简现代化（2ed23aa）+ docs 批 28 登记（4575bf8 / 918f3b3）+ 版本 bump 0.1.17（3d465b1）。

## 验证

- 709 passed, 2 subtests + ruff F/I-clean
- 版本四处一致：pyproject / `__init__` / plugin.json / tag