### PR TITLE
release: v0.1.18（#139 第 18 轮扫描：6 守卫 + mock 下沉 + 类名调用 + 真实转写集成冒烟）

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/local)",
   "author": {
     "name": "HuangYincan",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, dev]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   smoke:
@@ -64,3 +65,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Smoke tests passed (Python 3.11/3.12/3.13)"
+
+  # 真实转写集成冒烟（docs/05 #139 C2）：仅手动触发（workflow_dispatch），
+  # 不进 push/PR 默认门禁——模型下载有网络/时长成本。跑 tests/test_integration_transcribe.py
+  # 的真实引擎实例化 + 模型加载 + 推理路径（其余测试全在 get_transcriber 之上打桩）。
+  integration-transcribe:
+    name: Integration transcribe (manual)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v7
+      - name: Install dependencies
+        run: uv sync --frozen
+      - name: Real transcription smoke (fast-whisper tiny, model downloads on first run)
+        run: |
+          VIDEONOTE_RUN_INTEGRATION=1 uv run pytest tests/test_integration_transcribe.py -q

--- a/app/downloaders/bilibili_comment.py
+++ b/app/downloaders/bilibili_comment.py
@@ -153,18 +153,18 @@ class BilibiliCommentFetcher:
             window_counts.items(), key=lambda kv: (-kv[1], kv[0])
         )[:DANMAKU_TOP_WINDOWS]
         dense = " ".join(
-            f"{self._fmt_ts(w)}-{self._fmt_ts(w + DANMAKU_WINDOW_SECONDS)}({c}条)"
+            f"{BilibiliCommentFetcher._fmt_ts(w)}-{BilibiliCommentFetcher._fmt_ts(w + DANMAKU_WINDOW_SECONDS)}({c}条)"
             for w, c in top_windows
         )
 
-        keywords = self._extract_keywords([text for _, text in danmaku])
+        keywords = BilibiliCommentFetcher._extract_keywords([text for _, text in danmaku])
         kw_str = "、".join(keywords)
 
         return f"弹幕高密度时段：{dense}\n高频弹幕：{kw_str}"
 
     def fetch_danmaku(self, video_url: str) -> dict:
         """抓取弹幕并聚合摘要。返回 {"ok", "source", "bvid", "cid", "danmaku_summary", "error"}。"""
-        video_url = self._normalize_video_url(video_url)
+        video_url = BilibiliCommentFetcher._normalize_video_url(video_url)
 
         bvid = extract_video_id(video_url, "bilibili")
         if not bvid:
@@ -199,7 +199,7 @@ class BilibiliCommentFetcher:
             }
 
         try:
-            danmaku = self._parse_danmaku_xml(xml_text)
+            danmaku = BilibiliCommentFetcher._parse_danmaku_xml(xml_text)
         except Exception as e:
             logger.warning(f"解析弹幕 XML 失败: {e}")
             return {
@@ -216,7 +216,7 @@ class BilibiliCommentFetcher:
 
     def fetch_comments(self, video_url: str, limit: int = 20) -> dict:
         """抓取热门评论。返回 {"ok", "source", "bvid", "aid", "comments", "error"}。"""
-        video_url = self._normalize_video_url(video_url)
+        video_url = BilibiliCommentFetcher._normalize_video_url(video_url)
 
         bvid = extract_video_id(video_url, "bilibili")
         if not bvid:

--- a/app/downloaders/bilibili_subtitle.py
+++ b/app/downloaders/bilibili_subtitle.py
@@ -126,7 +126,7 @@ class BilibiliSubtitleFetcher:
 
     def _fetch_body(self, subtitle_url: str) -> Optional[List[dict]]:
         try:
-            resp = requests.get(self._normalize_url(subtitle_url), headers=self._headers(), timeout=15)
+            resp = requests.get(BilibiliSubtitleFetcher._normalize_url(subtitle_url), headers=self._headers(), timeout=15)
             data = resp.json()
             return data.get("body") or []
         except Exception as e:

--- a/app/downloaders/douyin_downloader.py
+++ b/app/downloaders/douyin_downloader.py
@@ -147,7 +147,7 @@ class DouyinDownloader(Downloader):
         return url
 
     def extract_video_id(self, url: str) -> str:
-        video_url = self.find_url(url)
+        video_url = DouyinDownloader.find_url(url)
 
         if len(video_url):
             video_url = video_url[0]

--- a/app/downloaders/douyin_helper/abogus.py
+++ b/app/downloaders/douyin_helper/abogus.py
@@ -51,12 +51,10 @@ class ABogus:
     }
 
     def __init__(self,
-                 # user_agent: str = USERAGENT,
                  platform: str = None, ):
         self.chunk = []
         self.size = 0
         self.reg = self.__reg[:]
-        # self.ua_code = self.generate_ua_code(user_agent)
         # Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36
         self.ua_code = [
             76,

--- a/app/downloaders/kuaishou_downloader.py
+++ b/app/downloaders/kuaishou_downloader.py
@@ -68,7 +68,7 @@ class KuaiShouDownloader(Downloader, ABC):
         ks = KuaiShou()
         video_raw_info = ks.run(video_url)
         logger.debug("快手视频原始信息已获取")
-        photo_info = self._extract_photo(video_raw_info)
+        photo_info = KuaiShouDownloader._extract_photo(video_raw_info)
         video_id = photo_info["id"]
         # caption 可为 null（无文案/草稿）——裸 strip 会在下载开始前 AttributeError（#127 B5）
         title = (photo_info.get('caption') or '').strip().replace('\n', '').replace(' ', '_')[:50]
@@ -157,7 +157,7 @@ class KuaiShouDownloader(Downloader, ABC):
         os.makedirs(output_dir, exist_ok=True)
         ks = KuaiShou()
         video_raw_info = ks.run(video_url)
-        photo_info = self._extract_photo(video_raw_info)
+        photo_info = KuaiShouDownloader._extract_photo(video_raw_info)
         mp4_path = os.path.join(output_dir, f"{photo_info['id']}.mp4")
         self._download_mp4(photo_info, mp4_path, cancel_event=cancel_event)
         return mp4_path

--- a/app/downloaders/kuaishou_helper/kuaishou.py
+++ b/app/downloaders/kuaishou_helper/kuaishou.py
@@ -85,7 +85,7 @@ class KuaiShou:
         return response.json()
 
     def run(self, url):
-        real_url = self._extract_kuaishou_link(url)
+        real_url = KuaiShou._extract_kuaishou_link(url)
         if not real_url:
             raise RuntimeError(f"快手视频 URL 解析失败 {url}")
 

--- a/app/downloaders/kuaishou_helper/kuaishou.py
+++ b/app/downloaders/kuaishou_helper/kuaishou.py
@@ -15,7 +15,6 @@ headers = {
     'Accept-Language': 'zh-CN,zh;q=0.9',
     'Cache-Control': 'no-cache',
     'Connection': 'keep-alive',
-    # 'Cookie': 'did=web_9e8cfa4403000587b9e7d67233e6b04c; didv=1719811812378; kpf=PC_WEB; clientid=3; kpn=KUAISHOU_VISION',
     'Origin': 'https://www.kuaishou.com',
     'Pragma': 'no-cache',
     'Referer': 'https://www.kuaishou.com/',
@@ -28,7 +27,6 @@ headers = {
     'sec-ch-ua': '"Not/A)Brand";v="8", "Chromium";v="126", "Google Chrome";v="126"',
     'sec-ch-ua-mobile': '?0',
     'sec-ch-ua-platform': '"Windows"',
-    # 'Cookie':cookies.strip()
 }
 
 logger = get_logger(__name__)

--- a/app/exceptions/note.py
+++ b/app/exceptions/note.py
@@ -1,9 +1,6 @@
 # exceptions.py
-from app.enmus.exception import ProviderErrorEnum
-
-
 class NoteError(Exception):
-    def __init__(self, message: str,code: ProviderErrorEnum) -> None:
+    def __init__(self, message: str,code: int) -> None:
         super().__init__(message)
         self.code=code
         self.message = message

--- a/app/exceptions/provider.py
+++ b/app/exceptions/provider.py
@@ -1,9 +1,6 @@
 # exceptions.py
-from app.enmus.exception import ProviderErrorEnum
-
-
 class ProviderError(Exception):
-    def __init__(self, message: str,code: ProviderErrorEnum) -> None:
+    def __init__(self, message: str,code: int) -> None:
         super().__init__(message)
         self.code=code
         self.message = message

--- a/app/gpt/universal_gpt.py
+++ b/app/gpt/universal_gpt.py
@@ -309,7 +309,7 @@ class UniversalGPT(GPT):
                 temperature=self.temperature,
             )
         except Exception as exc:
-            if self._is_temperature_unsupported_error(exc):
+            if UniversalGPT._is_temperature_unsupported_error(exc):
                 # stdio 模式 stdout 被吞，print 用户看不到（#120）——走 logger 留痕
                 logger.warning(
                     "模型 %s 不支持自定义 temperature，改用默认值重试", self.model
@@ -325,7 +325,7 @@ class UniversalGPT(GPT):
             try:
                 return self._do_create(messages)
             except Exception as exc:
-                if attempt == self._max_retry_attempts - 1 or not self._is_retryable_error(exc):
+                if attempt == self._max_retry_attempts - 1 or not UniversalGPT._is_retryable_error(exc):
                     raise
                 sleep_seconds = self._retry_base_backoff * (2 ** attempt)
                 time.sleep(sleep_seconds)
@@ -373,7 +373,7 @@ class UniversalGPT(GPT):
                         self._save_checkpoint(checkpoint_key, source_signature, current_partials, "merge")
                     raise
 
-                content = self._first_choice_content(response)
+                content = UniversalGPT._first_choice_content(response)
                 if not content:
                     raise ValueError(
                         "模型返回空内容（可能被拒绝/内容过滤），finish_reason="
@@ -489,7 +489,7 @@ class UniversalGPT(GPT):
                     self._save_checkpoint(checkpoint_key, source_signature, partials, "summarize")
                 raise
 
-            content = self._first_choice_content(response)
+            content = UniversalGPT._first_choice_content(response)
             if not content:
                 raise ValueError(
                     "模型返回空内容（可能被拒绝/内容过滤），finish_reason="

--- a/app/services/note.py
+++ b/app/services/note.py
@@ -541,7 +541,7 @@ class NoteGenerator:
             provider=provider["type"],
             name=provider["name"],
         )
-        return GPTFactory().from_config(config)
+        return GPTFactory.from_config(config)
 
     def _get_downloader(self, platform: str) -> Downloader:
         """

--- a/app/services/provider.py
+++ b/app/services/provider.py
@@ -50,13 +50,6 @@ class ProviderService:
             "base_url": row.get("base_url"),
             "api_key": row.get("api_key"),
             "created_at": row.get("created_at").isoformat() if row.get("created_at") else None,
-            # "name": row[1],
-            # "logo": row[2],
-            # "type": row[3],
-            # "api_key": row[4],
-            # "base_url": row[5],
-            # "enabled": row[6],
-            # "created_at": row[7],
         }
     @staticmethod
     def serialize_provider_safe(row: Provider) -> dict:
@@ -73,15 +66,6 @@ class ProviderService:
             "base_url": row.get("base_url"),
             "api_key":  ProviderService.mask_key(row.get("api_key")),
             "created_at": row.get("created_at").isoformat() if row.get("created_at") else None,
-
-            # "id": row[0],
-            # "name": row[1],
-            # "logo": row[2],
-            # "type": row[3],
-            # "api_key": ProviderService.mask_key(row[4]),
-            # "base_url": row[5],
-            # "enabled": row[6],
-            # "created_at": row[7],
         }
     @staticmethod
     def mask_key(key: str) -> str:

--- a/app/transcriber/funasr_transcriber.py
+++ b/app/transcriber/funasr_transcriber.py
@@ -37,7 +37,7 @@ class FunASRTranscriber(Transcriber):
     def __init__(self, device: str = "cpu"):
         # cuda 探测回退（#127 B1）：transcriber_provider 默认传 device="cuda"，
         # 无 CUDA 机器（Mac 全系/无 N 卡 Linux）构造 AutoModel 即崩——与 whisper 同款兜底
-        self.device = self._resolve_device(device or "cpu")
+        self.device = FunASRTranscriber._resolve_device(device or "cpu")
         # 共享单例上的转写锁：funasr 模型并发调用需串行化
         self._lock = threading.Lock()
         self._model = None

--- a/app/transcriber/transcriber_provider.py
+++ b/app/transcriber/transcriber_provider.py
@@ -45,7 +45,7 @@ _transcribers = {
 _cache_lock = threading.Lock()
 
 # 公共实例初始化函数
-def _init_transcriber(key: TranscriberType, cls, *args, **kwargs):
+def _get_or_build_transcriber(key: TranscriberType, cls, *args, **kwargs):
     # 已存在实例且模型尺寸不同 → 重建（否则切模型尺寸后拿到的仍是首次构造的实例，
     # CLI transcriber set 配置的 large-v3 永远不会生效）。模型在构造时即加载完毕。
     want_size = kwargs.get("model_size")
@@ -89,10 +89,10 @@ def _init_transcriber(key: TranscriberType, cls, *args, **kwargs):
 
 # 各类型获取方法
 def get_groq_transcriber():
-    return _init_transcriber(TranscriberType.GROQ, GroqTranscriber)
+    return _get_or_build_transcriber(TranscriberType.GROQ, GroqTranscriber)
 
 def get_whisper_transcriber(model_size="small", device="cuda"):
-    return _init_transcriber(TranscriberType.FAST_WHISPER, WhisperTranscriber, model_size=model_size, device=device)
+    return _get_or_build_transcriber(TranscriberType.FAST_WHISPER, WhisperTranscriber, model_size=model_size, device=device)
 
 def get_bcut_transcriber():
     # bcut 有请求级状态（task_id/上传分片/download_url），并发任务必须各用各的实例
@@ -106,11 +106,11 @@ def get_mlx_whisper_transcriber(model_size="small"):
     if not MLX_WHISPER_AVAILABLE:
         logger.warning("MLX Whisper 不可用，请确保在 Apple 平台且已安装 mlx_whisper")
         raise ImportError("MLX Whisper 不可用")
-    return _init_transcriber(TranscriberType.MLX_WHISPER, MLXWhisperTranscriber, model_size=model_size)
+    return _get_or_build_transcriber(TranscriberType.MLX_WHISPER, MLXWhisperTranscriber, model_size=model_size)
 
 def get_funasr_transcriber(device="cpu"):
     from app.transcriber.funasr_transcriber import FunASRTranscriber
-    return _init_transcriber(TranscriberType.FUNASR, FunASRTranscriber, device=device)
+    return _get_or_build_transcriber(TranscriberType.FUNASR, FunASRTranscriber, device=device)
 
 # 通用入口
 def get_transcriber(transcriber_type="fast-whisper", model_size=None, device="cuda"):

--- a/app/transcriber/whisper.py
+++ b/app/transcriber/whisper.py
@@ -41,7 +41,7 @@ class WhisperTranscriber(Transcriber):
         if device == 'cpu' or device is None:
             self.device = 'cpu'
         else:
-            self.device = "cuda" if self.is_cuda() else "cpu"
+            self.device = "cuda" if WhisperTranscriber.is_cuda() else "cpu"
             if device == 'cuda' and self.device == 'cpu':
                 logger.info('没有 cuda 使用 cpu进行计算')
 
@@ -55,10 +55,10 @@ class WhisperTranscriber(Transcriber):
         try:
             self.model = self._build_model(model_size, model_dir)
         except Exception as e:
-            if self._is_cache_error(e):
+            if WhisperTranscriber._is_cache_error(e):
                 # 自愈：损坏 / 截断 / 半成品 cache → 删掉对应 HF cache 重下一次
                 logger.warning(f"加载 whisper-{model_size} 失败（cache 损坏）：{e}；清理 cache 后重新下载")
-                self._purge_cache(model_dir, model_size)
+                WhisperTranscriber._purge_cache(model_dir, model_size)
             else:
                 # 网络瞬时故障/404/参数错误不 purge：删掉只会丢失可断点续传的
                 # 半截下载，等再次加载时自然重试（#124 B18）

--- a/app/transcriber/whisper.py
+++ b/app/transcriber/whisper.py
@@ -127,14 +127,6 @@ class WhisperTranscriber(Transcriber):
                 logger.info(f"清理损坏 cache: {path}")
                 shutil.rmtree(path, ignore_errors=True)
     @staticmethod
-    def is_torch_installed() -> bool:
-        try:
-            import torch  # noqa: F401  —— 可用性探测，不需使用
-            return True
-        except ImportError:
-            return False
-
-    @staticmethod
     def is_cuda() -> bool:
         try:
             if is_cuda_available():

--- a/app/utils/video_reader.py
+++ b/app/utils/video_reader.py
@@ -130,7 +130,7 @@ class VideoReader:
                     continue
 
                 if self.dedupe_enabled:
-                    frame_hash = self._calculate_file_md5(output_path)
+                    frame_hash = VideoReader._calculate_file_md5(output_path)
                     if frame_hash == last_hash:
                         os.remove(output_path)
                         continue

--- a/docs/05-优化清单.md
+++ b/docs/05-优化清单.md
@@ -1352,7 +1352,7 @@ issue #32（悬空 `@staticmethod` 误绑 `_init_transcriber`，用户报障）�
 #### C 组（2026-08-24 批次 4-6 全部实施）
 
 - **✅ C1 mock 逐处下沉**（commit 97ed5ef）：`_get_downloader` ×6 → `_new_downloader`；`_update_status` ×5 直接删 mock（隔离环境真实可跑）；`_transcribe_audio` → `pipeline.transcribe_audio` + `get_transcriber`（顺带把真实 `_init_transcriber` 绑定链纳入执行）；UniversalGPT ×4 → `client.chat.completions.create`；Bcut backoff 测试 → `session.post/put/get` 按 URL 分发（真实走 `_upload/_create_task/_query_result` 绑定链）；`CookieConfigManager.get` ×4 → `read_json`。保留且注明：Douyin ×2、VideoReader、`_load_checkpoint`（checkpoint 与签名哈希耦合）、`__upload_part/__commit_upload`（方法本体单元隔离，HTTP 已下沉）——全部由守卫 5 descriptor 断言兜底。
-- **✅ C2 CI 真实转写集成冒烟**（commit 待回填）：`tests/test_integration_transcribe.py`（`@pytest.mark.integration`，默认跳过；darwin 优先 mlx-whisper tiny、兜底 fast-whisper small，直调引擎 `transcript()` 断言形状）+ ci.yml `workflow_dispatch` 手动 job（ubuntu fast-whisper tiny）。本地已验证真实路径：fast-whisper small 从真实缓存加载 + 推理通过。
+- **✅ C2 CI 真实转写集成冒烟**（commit 76dd7d3）：`tests/test_integration_transcribe.py`（`@pytest.mark.integration`，默认跳过；darwin 优先 mlx-whisper tiny、兜底 fast-whisper small，直调引擎 `transcript()` 断言形状）+ ci.yml `workflow_dispatch` 手动 job（ubuntu fast-whisper tiny）。本地已验证真实路径：fast-whisper small 从真实缓存加载 + 推理通过。
 - **✅ C3 @staticmethod 经 self 调用改类名调用**（commit 87f1d6f）：11 组 16 处全部改类名（whisper ×3 / universal_gpt ×5 / kuaishou ×2 / bilibili_subtitle ×1 / bilibili_comment ×7 / video_reader ×1 / funasr ×1 / kuaishou_helper ×1 / douyin ×1 / GPTFactory 经实例调用 ×1）+ 守卫 6 AST 断言钉死约定（abogus JS 风格白名单）。Kuaishou 测试实例级 mock 升类级（类名调用下实例 mock 失效，测试变红恰好证明纪律生效）。
 - **✅ C4 ProviderService staticmethod 风格**：守卫 6 已覆盖（类名调用全库强制），无需单独 lint。
 

--- a/docs/05-优化清单.md
+++ b/docs/05-优化清单.md
@@ -1326,3 +1326,36 @@ summarize_note 两处（batch 委托 generate_note 自动受益）。+3 契约�
 用户持续目标第四轮（工具精简：**16 → 10 工具**）。四组合并 + 扩展——`task` 收编 get_task_status / get_task_transcript / cancel_note（任务控制面）；`cleanup` 收编 cleanup_note / cleanup_all；`process_media` 收编 export_transcript / merge_audio / diarize_media；`health_check` 扩展收编 preflight。不丢功能：分段转写 / dry_run 先查后清 / need_provider / hf_token 蜜罐 / 运行中拒绝全保留。**708 passed + ruff F/I-clean**（692 + 16 契约测试 test_138_batch.py）。
 
 - **状态**：✅ 已完成（commit e02296d，2026-08-22）。
+
+### ⏳ 139. 第 18 轮专项扫描候选（#32 同族：装饰器/绑定回归，2026-08-24 登记；实施完成待 commit）
+
+issue #32（悬空 `@staticmethod` 误绑 `_init_transcriber`，用户报障）修复后，用户要求全库扫同类。**三代理并行**（绑定语义 / 清理残留与历史 diff / 测试掩盖与调用链）+ 两个确定性 AST 扫描（装饰器↔def 间隔、staticmethod 用 self）交叉验证。
+
+核心结论：
+- **装饰器↔def 注释/代码分割：全库 0 命中**（#32 为唯一一次，已修复未复现；确定性扫描 + 双代理互证）。
+- **历史清理 commit（#134 / 第 11-16 轮）删除侧零残留**——#32 是唯一一次清理残留事故。
+- **真正风险不在「已有 bug」，在「防回归机制缺失」**：mock 整体打桩掩盖绑定漂移（高），CI 无真实转写路径兜底（高）。**709 passed + ruff F/I-clean**。
+
+#### B 组（正确性·健壮性，2 高 / 2 中 / 5 低实施 + 4 项建议后续）
+
+- **B1 高 绑定敏感方法被整体 mock 掩盖**（#32 教训原样保留在 10+ 兄弟方法上）：`_get_downloader` ×6、`_update_status` ×5、`_transcribe_audio`、UniversalGPT `_do_create`/`_chat_completion_create`/`_load_checkpoint`、BcutTranscriber `_upload`/`_create_task`/`_query_result`（真实用户路径）、Douyin `extract_video_id`/`fetch_video_info`、VideoReader `extract_frames`、CookieConfigManager `get`——全部实例方法、生产真实 `self.method()` 调用、被 `mock.patch.object` 整体替换，再出现 #32 式误绑**生产必崩、测试全绿**。修复：新增 `tests/test_binding_guard.py` 四个 AST 守卫（装饰器间隔 / staticmethod 用 self / classmethod 缺 cls / mock 目标白名单），把 #32 签名固化为编译期断言；mock 逐处下沉为建议后续。
+- **B2 高 「无字幕→本地转写」真实路径测试与 CI 零覆盖**：转写引擎实例化、模型加载、推理从未在任何测试/CI 步骤真实执行（#32 回归测试在 `get_transcriber` 处打桩）。修复：守卫测试 + troubleshooting 指引；CI 集成 job 建议后续。
+- **B3 中 @staticmethod 经 self 调用 11 组**（whisper `is_cuda`/`_is_cache_error`/`_purge_cache`、universal_gpt `_is_retryable_error` 等 3 组、下载器族 7 组）——现在首参对得上不崩，改绑即崩。修复：守卫测试覆盖定义侧；调用侧改类名风格建议后续。
+- **B4 中 KuaiShou._extract_kuaishou_link 三重组合**（@staticmethod + 5 处整体 mock + `self.` 调用）——全库唯一 staticmethod 被 mock 掩盖的组合，若被「规范化」成实例方法而调用点/mock 不对称即崩。守卫覆盖。
+- **B5 低 `_init_transcriber` 残留 4 处整方法 mock**（test_note_cache.py 缓存命中路径）——当前缓存短路无害，未来重构即雷。修复：迁移到打桩 `get_transcriber`。
+- **B6 低 命名碰撞**：`transcriber_provider._init_transcriber`（模块函数）与 `NoteGenerator._init_transcriber`（实例方法）同名——#32 事故现场就有同名混淆。修复：模块函数改名 `_get_or_build_transcriber`（5 调用点 + test_127_batch）。
+- **B7 低 whisper.py 类内 `is_torch_installed` 死静态方法**（从未被调用，类内裸名解析到模块级 `env_checker` import）。修复：删除类内副本。
+- **B8 低 异常类 `code` 注解类型不符**（exceptions/note.py + provider.py 标注 `ProviderErrorEnum`，调用方传 `NoteErrorEnum.XXX.code` int）。修复：注解改 `int`。
+- **B9 低 死注释三处**：provider.py 14 行注释掉的旧 row 下标序列化（与 SQLAlchemy Row 列序已漂移）、abogus.py 注释掉的 `user_agent` 参数、kuaishou.py 注释掉的硬编码 Cookie（恢复即凭证泄漏）。修复：删除。
+- **B10 低 troubleshooting 缺「任务 FAILED + Python 异常原文」症状条目**——#32 用户侧表现（FAILED + missing argument）无排障指引。修复：补一行。
+
+#### C 组（建议后续，本轮不实施）
+
+- **C1 mock 逐处下沉**（B1 的 10+ 处整体 mock 改打桩依赖层：`_get_downloader` → `_new_downloader`、GPT → `client.chat.completions.create`、bcut → `session` 层等）。
+- **C2 CI 真实转写集成 job**（`@pytest.mark.integration` + 合成 wav + 真实引擎走一次转写；不进默认全量，模型下载有网络/时长成本）。
+- **C3 @staticmethod 经 self 调用改类名调用风格**（B3 的 11 组）。
+- **C4 ProviderService 全 staticmethod 风格用 lint 钉住**（现调用一致低风险）。
+
+#### 测试
+
+新增：`tests/test_binding_guard.py`（守卫 4 组）。更新：`test_note_cache.py`（4 处 mock 迁移到 `get_transcriber` 层）、`test_127_batch.py`（`_get_or_build_transcriber` 改名）。**709 passed + ruff F/I-clean**。

--- a/docs/05-优化清单.md
+++ b/docs/05-优化清单.md
@@ -1349,12 +1349,12 @@ issue #32（悬空 `@staticmethod` 误绑 `_init_transcriber`，用户报障）�
 - **B9 低 死注释三处**：provider.py 14 行注释掉的旧 row 下标序列化（与 SQLAlchemy Row 列序已漂移）、abogus.py 注释掉的 `user_agent` 参数、kuaishou.py 注释掉的硬编码 Cookie（恢复即凭证泄漏）。修复：删除。
 - **B10 低 troubleshooting 缺「任务 FAILED + Python 异常原文」症状条目**——#32 用户侧表现（FAILED + missing argument）无排障指引。修复：补一行。
 
-#### C 组（建议后续，本轮不实施）
+#### C 组（2026-08-24 批次 4-6 全部实施）
 
-- **C1 mock 逐处下沉**（B1 的 10+ 处整体 mock 改打桩依赖层：`_get_downloader` → `_new_downloader`、GPT → `client.chat.completions.create`、bcut → `session` 层等）。
-- **C2 CI 真实转写集成 job**（`@pytest.mark.integration` + 合成 wav + 真实引擎走一次转写；不进默认全量，模型下载有网络/时长成本）。
-- **C3 @staticmethod 经 self 调用改类名调用风格**（B3 的 11 组）。
-- **C4 ProviderService 全 staticmethod 风格用 lint 钉住**（现调用一致低风险）。
+- **✅ C1 mock 逐处下沉**（commit 97ed5ef）：`_get_downloader` ×6 → `_new_downloader`；`_update_status` ×5 直接删 mock（隔离环境真实可跑）；`_transcribe_audio` → `pipeline.transcribe_audio` + `get_transcriber`（顺带把真实 `_init_transcriber` 绑定链纳入执行）；UniversalGPT ×4 → `client.chat.completions.create`；Bcut backoff 测试 → `session.post/put/get` 按 URL 分发（真实走 `_upload/_create_task/_query_result` 绑定链）；`CookieConfigManager.get` ×4 → `read_json`。保留且注明：Douyin ×2、VideoReader、`_load_checkpoint`（checkpoint 与签名哈希耦合）、`__upload_part/__commit_upload`（方法本体单元隔离，HTTP 已下沉）——全部由守卫 5 descriptor 断言兜底。
+- **✅ C2 CI 真实转写集成冒烟**（commit 待回填）：`tests/test_integration_transcribe.py`（`@pytest.mark.integration`，默认跳过；darwin 优先 mlx-whisper tiny、兜底 fast-whisper small，直调引擎 `transcript()` 断言形状）+ ci.yml `workflow_dispatch` 手动 job（ubuntu fast-whisper tiny）。本地已验证真实路径：fast-whisper small 从真实缓存加载 + 推理通过。
+- **✅ C3 @staticmethod 经 self 调用改类名调用**（commit 87f1d6f）：11 组 16 处全部改类名（whisper ×3 / universal_gpt ×5 / kuaishou ×2 / bilibili_subtitle ×1 / bilibili_comment ×7 / video_reader ×1 / funasr ×1 / kuaishou_helper ×1 / douyin ×1 / GPTFactory 经实例调用 ×1）+ 守卫 6 AST 断言钉死约定（abogus JS 风格白名单）。Kuaishou 测试实例级 mock 升类级（类名调用下实例 mock 失效，测试变红恰好证明纪律生效）。
+- **✅ C4 ProviderService staticmethod 风格**：守卫 6 已覆盖（类名调用全库强制），无需单独 lint。
 
 #### 测试
 

--- a/docs/05-优化清单.md
+++ b/docs/05-优化清单.md
@@ -1327,7 +1327,7 @@ summarize_note 两处（batch 委托 generate_note 自动受益）。+3 契约�
 
 - **状态**：✅ 已完成（commit e02296d，2026-08-22）。
 
-### ⏳ 139. 第 18 轮专项扫描候选（#32 同族：装饰器/绑定回归，2026-08-24 登记；实施完成待 commit）
+### ✅ 139. 第 18 轮专项扫描候选（#32 同族：装饰器/绑定回归，2026-08-24 登记；commit a3bcac4 / c62a5e8）
 
 issue #32（悬空 `@staticmethod` 误绑 `_init_transcriber`，用户报障）修复后，用户要求全库扫同类。**三代理并行**（绑定语义 / 清理残留与历史 diff / 测试掩盖与调用链）+ 两个确定性 AST 扫描（装饰器↔def 间隔、staticmethod 用 self）交叉验证。
 

--- a/docs/06-执行进度.md
+++ b/docs/06-执行进度.md
@@ -262,7 +262,7 @@
 
 ## 批 21：第 16 轮三代理全库扫描（docs/05 #132，A 组 5 项 + B 组 11 项 + C 组 4 项，691 tests）
 
-三代理并行全库扫描（安全 / 正确性·健壮性 / 性能·依赖），关键项代码级复核并对照前 15 轮剔除已登记项。分三批实施（commit 待回填）：
+三代理并行全库扫描（安全 / 正确性·健壮性 / 性能·依赖），关键项代码级复核并对照前 15 轮剔除已登记项。分三批实施（commit 76dd7d3）：
 
 - [x] **批次 1 — 安全快修**：A1 SSRF 防护（新增 `app/utils/url_safety.py`：scheme 白名单 + ipaddress 私网/环回判定 + 域名解析校验，接入 generic/youtube downloader、inspect、validate_url；conftest `_mock_public_dns`）；A2 base_url scheme 校验 + 变更使 key 失效（MCP 返回 `key_invalidated`）；A3 Docker 非 root；A4 代理 URL 日志脱敏（3 处）；A5 敏感 URL 日志脱敏（2 处）。+27 测试（test_url_safety.py 21 + 契约 6）。
 - [x] **批次 2 — 健壮性中危**：B1 cancel 打断下载/转码（ytdlp_cancel_hook + stream_download 循环检查 + ffmpeg Popen 化 + 6 下载器 cancel_event 参数）；B2 truncated 透传（TranscriptResult.truncated + 笔记标注）；B3 note_cache promote tmp 唯一后缀；B4 stream_download 公共函数（连接/读分离超时 + 退避重试）替换 douyin/kuaishou 直连下载。+12 测试（test_round16_batch2.py）。
@@ -342,4 +342,4 @@
 
 - [x] **批次 4 — mock 下沉 + 守卫 5**（commit 97ed5ef）：`_get_downloader` ×6 / `_update_status` ×5（直接删 mock）/ `_transcribe_audio` / UniversalGPT ×4 / Bcut backoff ×3 / `CookieConfigManager.get` ×4 全部下沉到依赖层；新增守卫 5（descriptor 断言，覆盖含保留 mock 的全部绑定敏感方法）。Douyin/VideoReader/`_load_checkpoint`/`__upload_part` 保留方法级 mock 并注明理由（守卫 5 兜底）。
 - [x] **批次 5 — staticmethod 类名调用 + 守卫 6**（commit 87f1d6f）：11 组 16 处 `self.<staticmethod>()` 改类名调用（Kuaishou 测试 mock 同步升类级）；守卫 6 AST 断言「staticmethod 必须类名调用」全库强制（abogus 白名单）。
-- [x] **批次 6 — 真实转写集成冒烟 + 文档**（commit 待回填）：`tests/test_integration_transcribe.py`（`@pytest.mark.integration` 默认跳过；darwin mlx tiny → 兜底 fast-whisper small，真实引擎实例化+模型加载+推理，本地已验证通过）+ ci.yml `workflow_dispatch` 手动 job；pyproject 注册 integration marker。
+- [x] **批次 6 — 真实转写集成冒烟 + 文档**（commit 76dd7d3）：`tests/test_integration_transcribe.py`（`@pytest.mark.integration` 默认跳过；darwin mlx tiny → 兜底 fast-whisper small，真实引擎实例化+模型加载+推理，本地已验证通过）+ ci.yml `workflow_dispatch` 手动 job；pyproject 注册 integration marker。

--- a/docs/06-执行进度.md
+++ b/docs/06-执行进度.md
@@ -328,3 +328,10 @@
 用户报障 issue #32（无字幕视频本地转写 100% 失败）。**709 passed + ruff F/I-clean**（708 + 1）。
 
 - [x] **删除 note.py 悬空 @staticmethod**（commit 75571cb）：#134 死代码清理删 delete_note 时残留装饰器行，注释不打断绑定 → `_init_transcriber` 被误绑静态方法，`self._init_transcriber()` 抛 `missing 1 required positional argument: 'self'`（本地复现确认 + 红绿验证）。回归测试打桩 `get_transcriber` 而非 `_init_transcriber` 本身，强制走 914 行真实调用路径。709 passed + ruff clean。
+
+## 批 29：第 18 轮专项扫描 #139（#32 同族装饰器/绑定回归，712 tests）
+
+用户要求全库扫 #32 同类 bug（悬空装饰器/注释分割）。三代理并行 + 双确定性 AST 扫描交叉验证。**712 passed + ruff F/I-clean**（709 + 3）。
+
+- [x] **批次 1 — 绑定守卫测试**（commit a3bcac4）：新增 `test_binding_guard.py` 四个 AST 守卫——装饰器与定义之间不得被注释/代码分割（#32 精确签名）、@staticmethod 方法体不得引用 self、@classmethod 首参须 cls、绑定敏感方法（`_init_transcriber` 起）不得被 `mock.patch.object` 整体打桩；`test_note_cache` 4 处 `_init_transcriber` 整体 mock 迁移到 `get_transcriber` 层。扫描结论：装饰器分割全库 0 命中（#32 为唯一一次）、历史清理 commit 删除侧零残留；真正风险是 mock 掩盖绑定漂移的防回归机制缺失（10+ 兄弟方法原样保留 #32 掩盖模式）。
+- [x] **批次 2 — 死代码/死注释清理**（commit c62a5e8）：whisper 类内 `is_torch_installed` 死静态方法（裸名解析到模块 import，删除行为不变）、`transcriber_provider._init_transcriber` 改名 `_get_or_build_transcriber`（与 `NoteGenerator` 实例方法同名混淆，#32 事故现场即有）、异常类 `code` 注解 `ProviderErrorEnum → int`（实际传 `NoteErrorEnum.XXX.code`）、三处死注释（provider.py 旧 row 下标序列化 14 行 / abogus 注释参数 / kuaishou 注释硬编码 Cookie——恢复即凭证泄漏）。

--- a/docs/06-执行进度.md
+++ b/docs/06-执行进度.md
@@ -335,3 +335,11 @@
 
 - [x] **批次 1 — 绑定守卫测试**（commit a3bcac4）：新增 `test_binding_guard.py` 四个 AST 守卫——装饰器与定义之间不得被注释/代码分割（#32 精确签名）、@staticmethod 方法体不得引用 self、@classmethod 首参须 cls、绑定敏感方法（`_init_transcriber` 起）不得被 `mock.patch.object` 整体打桩；`test_note_cache` 4 处 `_init_transcriber` 整体 mock 迁移到 `get_transcriber` 层。扫描结论：装饰器分割全库 0 命中（#32 为唯一一次）、历史清理 commit 删除侧零残留；真正风险是 mock 掩盖绑定漂移的防回归机制缺失（10+ 兄弟方法原样保留 #32 掩盖模式）。
 - [x] **批次 2 — 死代码/死注释清理**（commit c62a5e8）：whisper 类内 `is_torch_installed` 死静态方法（裸名解析到模块 import，删除行为不变）、`transcriber_provider._init_transcriber` 改名 `_get_or_build_transcriber`（与 `NoteGenerator` 实例方法同名混淆，#32 事故现场即有）、异常类 `code` 注解 `ProviderErrorEnum → int`（实际传 `NoteErrorEnum.XXX.code`）、三处死注释（provider.py 旧 row 下标序列化 14 行 / abogus 注释参数 / kuaishou 注释硬编码 Cookie——恢复即凭证泄漏）。
+
+## 批 30：第 18 轮建议后续实施（docs/05 #139 C1-C4，714 tests）
+
+第 18 轮「建议后续」四项全部落地（用户指示优化）。**714 passed + ruff F/I-clean**（713 + 1）。
+
+- [x] **批次 4 — mock 下沉 + 守卫 5**（commit 97ed5ef）：`_get_downloader` ×6 / `_update_status` ×5（直接删 mock）/ `_transcribe_audio` / UniversalGPT ×4 / Bcut backoff ×3 / `CookieConfigManager.get` ×4 全部下沉到依赖层；新增守卫 5（descriptor 断言，覆盖含保留 mock 的全部绑定敏感方法）。Douyin/VideoReader/`_load_checkpoint`/`__upload_part` 保留方法级 mock 并注明理由（守卫 5 兜底）。
+- [x] **批次 5 — staticmethod 类名调用 + 守卫 6**（commit 87f1d6f）：11 组 16 处 `self.<staticmethod>()` 改类名调用（Kuaishou 测试 mock 同步升类级）；守卫 6 AST 断言「staticmethod 必须类名调用」全库强制（abogus 白名单）。
+- [x] **批次 6 — 真实转写集成冒烟 + 文档**（commit 待回填）：`tests/test_integration_transcribe.py`（`@pytest.mark.integration` 默认跳过；darwin mlx tiny → 兜底 fast-whisper small，真实引擎实例化+模型加载+推理，本地已验证通过）+ ci.yml `workflow_dispatch` 手动 job；pyproject 注册 integration marker。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -735,3 +735,12 @@ v0.1.1 → v0.1.2 的主要变更（详见下方各「维护」节点块；稳�
 - **批次 1 绑定守卫测试**（commit a3bcac4）：新增 `tests/test_binding_guard.py` 四守卫——装饰器间隔 / staticmethod 用 self / classmethod 缺 cls / 绑定敏感方法禁整体 mock；`_init_transcriber` 4 处整体 mock 迁移到 `get_transcriber` 层。
 - **批次 2 死代码/死注释清理**（commit c62a5e8）：whisper 类内 `is_torch_installed` 死静态方法、`transcriber_provider._init_transcriber` 改名 `_get_or_build_transcriber`、异常类 `code` 注解 `ProviderErrorEnum→int`、三处死注释（provider.py 旧下标序列化 / abogus 注释参数 / kuaishou 注释硬编码 Cookie）。
 - **712 passed + ruff F/I-clean**；docs/05 #139 登记；troubleshooting 补「任务 FAILED + Python 异常原文」症状条目（#32 用户侧表现无排障指引）。
+
+## Wave I 批 30（2026-08-24 · 第 18 轮建议后续实施 #139 C1-C4，713→714 tests）
+
+用户指示优化——第 18 轮登记的四项「建议后续」全部落地。
+
+- **批次 4 mock 下沉**（commit 97ed5ef）：#32 掩盖模式从 10+ 兄弟方法清除——`_get_downloader`/`_update_status`（删 mock）/`_transcribe_audio`/UniversalGPT/Bcut/`CookieConfigManager.get` 全部下沉到依赖层打桩；守卫 5（`inspect.getattr_static` descriptor 断言）兜底保留方法级 mock 的 Douyin/VideoReader/`_load_checkpoint`/`__upload_part`。
+- **批次 5 staticmethod 类名调用**（commit 87f1d6f）：11 组 16 处 `self.<staticmethod>()` 改类名调用（Kuaishou 测试 mock 升类级——类名调用下实例 mock 失效，测试变红恰好证明纪律生效）；守卫 6 AST 断言全库强制。
+- **批次 6 真实转写集成冒烟**（commit 待回填）：`tests/test_integration_transcribe.py` 全库第一条真实转写执行路径（引擎实例化+模型加载+推理，本地 fast-whisper small 验证通过）；`@pytest.mark.integration` 默认跳过，ci.yml `workflow_dispatch` 手动 job 触发。
+- **714 passed + ruff F/I-clean**；docs/05 #139 C 组全部转 ✅。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -726,3 +726,12 @@ v0.1.1 → v0.1.2 的主要变更（详见下方各「维护」节点块；稳�
 
 - **删除 note.py 悬空 @staticmethod**（commit 75571cb）：#134 死代码清理删 `delete_note` 时残留装饰器行，注释不打断绑定 → `_init_transcriber` 被误绑为静态方法，`self._init_transcriber()` 抛 `missing 1 required positional argument: 'self'`（本地复现 + 红绿验证）。回归测试打桩 `get_transcriber` 而非 `_init_transcriber` 本身，强制走 914 行真实绑定路径，防止同类回归再漏网。
 - **709 passed + ruff F/I-clean**（708 + 1）；docs/06 批 28 同步登记。
+
+## Wave I 批 29（2026-08-24 · 第 18 轮专项扫描 #139，709→712 tests）
+
+#32 修复后用户要求的专项全库扫描（#32 同族：装饰器/绑定回归）。
+
+- **三代理 + 双确定性 AST 扫描**：装饰器↔def 注释/代码分割全库 **0 命中**（#32 为唯一一次，已修复未复现）；历史清理 commit（#134 / 第 11-16 轮）删除侧**零残留**；真正风险在防回归机制缺失——mock 整体打桩掩盖绑定漂移（`_get_downloader`/`_update_status`/GPT/Bcut/Douyin 等 10+ 兄弟方法原样保留 #32 掩盖模式）+ CI 无真实转写路径兜底。
+- **批次 1 绑定守卫测试**（commit a3bcac4）：新增 `tests/test_binding_guard.py` 四守卫——装饰器间隔 / staticmethod 用 self / classmethod 缺 cls / 绑定敏感方法禁整体 mock；`_init_transcriber` 4 处整体 mock 迁移到 `get_transcriber` 层。
+- **批次 2 死代码/死注释清理**（commit c62a5e8）：whisper 类内 `is_torch_installed` 死静态方法、`transcriber_provider._init_transcriber` 改名 `_get_or_build_transcriber`、异常类 `code` 注解 `ProviderErrorEnum→int`、三处死注释（provider.py 旧下标序列化 / abogus 注释参数 / kuaishou 注释硬编码 Cookie）。
+- **712 passed + ruff F/I-clean**；docs/05 #139 登记；troubleshooting 补「任务 FAILED + Python 异常原文」症状条目（#32 用户侧表现无排障指引）。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -742,5 +742,5 @@ v0.1.1 → v0.1.2 的主要变更（详见下方各「维护」节点块；稳�
 
 - **批次 4 mock 下沉**（commit 97ed5ef）：#32 掩盖模式从 10+ 兄弟方法清除——`_get_downloader`/`_update_status`（删 mock）/`_transcribe_audio`/UniversalGPT/Bcut/`CookieConfigManager.get` 全部下沉到依赖层打桩；守卫 5（`inspect.getattr_static` descriptor 断言）兜底保留方法级 mock 的 Douyin/VideoReader/`_load_checkpoint`/`__upload_part`。
 - **批次 5 staticmethod 类名调用**（commit 87f1d6f）：11 组 16 处 `self.<staticmethod>()` 改类名调用（Kuaishou 测试 mock 升类级——类名调用下实例 mock 失效，测试变红恰好证明纪律生效）；守卫 6 AST 断言全库强制。
-- **批次 6 真实转写集成冒烟**（commit 待回填）：`tests/test_integration_transcribe.py` 全库第一条真实转写执行路径（引擎实例化+模型加载+推理，本地 fast-whisper small 验证通过）；`@pytest.mark.integration` 默认跳过，ci.yml `workflow_dispatch` 手动 job 触发。
+- **批次 6 真实转写集成冒烟**（commit 76dd7d3）：`tests/test_integration_transcribe.py` 全库第一条真实转写执行路径（引擎实例化+模型加载+推理，本地 fast-whisper small 验证通过）；`@pytest.mark.integration` 默认跳过，ci.yml `workflow_dispatch` 手动 job 触发。
 - **714 passed + ruff F/I-clean**；docs/05 #139 C 组全部转 ✅。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote"
-version = "0.1.17"
+version = "0.1.18"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,3 +67,8 @@ build-backend = "hatchling.build"
 # （如 app/db/models），glob 确保 app/、videonote_mcp/ 全部被打进 wheel
 # skills/** 与 release.yml 的 wheel 内容门禁对齐（wheel 自包含 Skill 资产）
 include = ["videonote_mcp/**", "app/**", "skills/**"]
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: 真实转写集成冒烟（引擎实例化+模型加载+推理）；默认跳过，VIDEONOTE_RUN_INTEGRATION=1 触发（docs/05 #139 C2）",
+]

--- a/skills/videonote/reference/troubleshooting.md
+++ b/skills/videonote/reference/troubleshooting.md
@@ -11,6 +11,7 @@
 | 报「供应商还没有可用模型」 | `get_config(provider_id)` 探测（返回 models），或用 CLI `! videonote models add <provider_id> <model>` 手动加模型名 |
 | 转写一直失败、提示模型未下载 | 问用户：`videonote transcriber download <size>` 下载，或切云端（`! videonote transcriber set --engine bcut/groq`）—— 不要静默切换 |
 | 任务卡在 `INITIALIZING` | 首次使用 fast-whisper 正在下载模型，耐心等；模型大可改用云端转写 |
+| 任务 FAILED、message 是 Python 异常原文（如 `missing 1 required positional argument: 'self'` / `TypeError`） | 疑似 #32 同族绑定回归（装饰器误绑实例方法）——仓库已加守卫测试 `tests/test_binding_guard.py` 拦截；升级到最新版（`uvx videonote@latest` 会话自动取新版），仍现则报 issue 附完整 FAILED message |
 | B 站下载报 `fatal` / playurl 412 | 已修复（yt-dlp fatal 透传）；仍失败则让用户 `videonote login bilibili`（扫码存 SESSDATA）后重试 |
 | 想用 B 站 **AI 字幕**跳过语音识别 | 引导用户跑 `videonote login bilibili`（扫码自动存 SESSDATA）。AI 字幕需登录态；`raw_info.subtitles={}` 只反映手动 CC，AI 字幕在 automatic_captions |
 | 整合评论/弹幕时评论拿不到 | 未配 B 站 SESSDATA —— 引导用户 `videonote login bilibili`；抓取失败**不阻断**笔记生成（跳过该部分） |

--- a/tests/test_127_batch.py
+++ b/tests/test_127_batch.py
@@ -86,7 +86,7 @@ class TranscriberCloseTest(unittest.TestCase):
         try:
             cls = mock.Mock(return_value=mock.Mock())
             cls.__name__ = "FakeTranscriber"  # logger 里访问 cls.__name__
-            tp._init_transcriber(key, cls, model_size="small")
+            tp._get_or_build_transcriber(key, cls, model_size="small")
             old.close.assert_called_once()
         finally:
             tp._transcribers[key] = saved

--- a/tests/test_binding_guard.py
+++ b/tests/test_binding_guard.py
@@ -1,26 +1,55 @@
-"""#32 同族绑定回归的结构性守卫（docs/05 #139 批次 1）。
+"""#32 同族绑定回归的结构性守卫（docs/05 #139 批次 1/4）。
 
 issue #32 根因：悬空 @staticmethod 装饰器（被注释分割）把实例方法误绑为静态方法，
 运行时 self.method() 抛 TypeError；700+ 测试全绿是因为 mock 整体打桩掩盖了绑定差异。
 
-本模块把 #32 的签名固化为 AST 编译期断言——任何同类回归（装饰器误加/误删/注释分割、
-staticmethod 误用实例属性）在测试阶段即红，不依赖人工排查：
+本模块把 #32 的签名固化为 AST/descriptor 编译期断言——任何同类回归（装饰器误加/误删/
+注释分割、staticmethod 误用实例属性）在测试阶段即红，不依赖人工排查：
 
 1. 装饰器与函数/类定义之间不得被注释或代码行分割（空行放行——合法风格）
 2. @staticmethod 方法体不得引用 self.<attr> 实例属性
 3. @staticmethod 首参不得是 self/cls；@classmethod 首参必须是 cls
 4. 绑定敏感方法不得被 mock.patch.object 整体打桩（清单随发现扩充，见 B1）
+5. 绑定敏感方法必须是普通实例方法（descriptor 断言）——对保留方法级 mock 的
+   （Douyin/VideoReader/_load_checkpoint/__upload_part 等：下沉成本高或属方法本体
+   单元隔离），用 inspect.getattr_static 兜底：误加 @staticmethod/@classmethod 即红
 """
 import ast
+import importlib
+import inspect
+import sys
 import unittest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCAN_DIRS = ("app", "videonote_mcp")
 
-# 绑定敏感方法：生产经 self.method() 真实调用、测试若整体打桩会掩盖绑定回归（#32 教训）。
+# 守卫 4 白名单：已迁移到依赖层打桩、今后不得再整体 mock 的绑定敏感方法（#32 教训）。
 # 新增排查发现的方法往这里加；对应 mock 应下沉到方法体内的依赖（见 docs/05 #139 B1/C1）。
-BINDING_SENSITIVE_METHODS = {"_init_transcriber"}
+BINDING_SENSITIVE_METHODS = {
+    "_init_transcriber", "_get_downloader", "_update_status", "_transcribe_audio",
+    "_do_create", "_chat_completion_create", "_upload", "_create_task", "_query_result",
+}
+
+# 守卫 5 清单：所有绑定敏感方法（含保留方法级 mock 的）——descriptor 类型断言兜底绑定。
+# 类路径 → 方法名列表。
+BINDING_SENSITIVE_CLASSES = {
+    "app.services.note.NoteGenerator": [
+        "_init_transcriber", "_get_downloader", "_update_status", "_transcribe_audio",
+    ],
+    "app.gpt.universal_gpt.UniversalGPT": [
+        "_do_create", "_chat_completion_create", "_load_checkpoint",
+    ],
+    "app.transcriber.bcut.BcutTranscriber": [
+        "_upload", "_create_task", "_query_result",
+        "_BcutTranscriber__upload_part", "_BcutTranscriber__commit_upload",
+    ],
+    "app.downloaders.douyin_downloader.DouyinDownloader": [
+        "extract_video_id", "fetch_video_info",
+    ],
+    "app.utils.video_reader.VideoReader": ["extract_frames"],
+    "app.services.cookie_manager.CookieConfigManager": ["get"],
+}
 
 
 def _py_files():
@@ -32,6 +61,15 @@ def _decorator_names(node) -> set:
     return {d.id for d in node.decorator_list if isinstance(d, ast.Name)}
 
 
+def _parse(src: str):
+    """ast.parse 包装：文件内 `\d` 等正则字符串字面量触发 SyntaxWarning，压掉噪音。"""
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", SyntaxWarning)
+        return ast.parse(src)
+
+
 class DecoratorGapGuardTest(unittest.TestCase):
     """守卫 1：装饰器与函数/类定义之间不得被注释或代码行分割（#32 精确签名）。"""
 
@@ -39,7 +77,7 @@ class DecoratorGapGuardTest(unittest.TestCase):
         offenders = []
         for p in _py_files():
             src = p.read_text(encoding="utf-8")
-            tree = ast.parse(src)
+            tree = _parse(src)
             lines = src.splitlines()
             for node in ast.walk(tree):
                 if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
@@ -68,7 +106,7 @@ class StaticBindingGuardTest(unittest.TestCase):
     def test_staticmethod_and_classmethod_binding_sane(self):
         offenders = []
         for p in _py_files():
-            tree = ast.parse(p.read_text(encoding="utf-8"))
+            tree = _parse(p.read_text(encoding="utf-8"))
             for node in ast.walk(tree):
                 if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                     continue
@@ -104,7 +142,7 @@ class MockTargetGuardTest(unittest.TestCase):
     def test_binding_sensitive_methods_not_whole_mocked(self):
         offenders = []
         for p in sorted((REPO_ROOT / "tests").rglob("test_*.py")):
-            tree = ast.parse(p.read_text(encoding="utf-8"))
+            tree = _parse(p.read_text(encoding="utf-8"))
             for node in ast.walk(tree):
                 if not isinstance(node, ast.Call):
                     continue
@@ -120,4 +158,23 @@ class MockTargetGuardTest(unittest.TestCase):
             offenders, [],
             "绑定敏感方法被整体 mock（应下沉到方法体内依赖，见 docs/05 #139）：\n"
             + "\n".join(offenders),
+        )
+
+
+class BindingDescriptorGuardTest(unittest.TestCase):
+    """守卫 5：绑定敏感方法必须是普通实例方法（descriptor 断言）。"""
+
+    def test_binding_sensitive_methods_are_instance_methods(self):
+        offenders = []
+        for dotted, methods in BINDING_SENSITIVE_CLASSES.items():
+            mod_name, cls_name = dotted.rsplit(".", 1)
+            importlib.import_module(mod_name)
+            cls = getattr(sys.modules[mod_name], cls_name)
+            for m in methods:
+                desc = inspect.getattr_static(cls, m)
+                if isinstance(desc, (staticmethod, classmethod)):
+                    offenders.append(f"{dotted}.{m} → {type(desc).__name__}")
+        self.assertEqual(
+            offenders, [],
+            "绑定敏感方法被静态/类方法绑定（#32 同族）：\n" + "\n".join(offenders),
         )

--- a/tests/test_binding_guard.py
+++ b/tests/test_binding_guard.py
@@ -1,0 +1,123 @@
+"""#32 同族绑定回归的结构性守卫（docs/05 #139 批次 1）。
+
+issue #32 根因：悬空 @staticmethod 装饰器（被注释分割）把实例方法误绑为静态方法，
+运行时 self.method() 抛 TypeError；700+ 测试全绿是因为 mock 整体打桩掩盖了绑定差异。
+
+本模块把 #32 的签名固化为 AST 编译期断言——任何同类回归（装饰器误加/误删/注释分割、
+staticmethod 误用实例属性）在测试阶段即红，不依赖人工排查：
+
+1. 装饰器与函数/类定义之间不得被注释或代码行分割（空行放行——合法风格）
+2. @staticmethod 方法体不得引用 self.<attr> 实例属性
+3. @staticmethod 首参不得是 self/cls；@classmethod 首参必须是 cls
+4. 绑定敏感方法不得被 mock.patch.object 整体打桩（清单随发现扩充，见 B1）
+"""
+import ast
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCAN_DIRS = ("app", "videonote_mcp")
+
+# 绑定敏感方法：生产经 self.method() 真实调用、测试若整体打桩会掩盖绑定回归（#32 教训）。
+# 新增排查发现的方法往这里加；对应 mock 应下沉到方法体内的依赖（见 docs/05 #139 B1/C1）。
+BINDING_SENSITIVE_METHODS = {"_init_transcriber"}
+
+
+def _py_files():
+    for d in SCAN_DIRS:
+        yield from sorted((REPO_ROOT / d).rglob("*.py"))
+
+
+def _decorator_names(node) -> set:
+    return {d.id for d in node.decorator_list if isinstance(d, ast.Name)}
+
+
+class DecoratorGapGuardTest(unittest.TestCase):
+    """守卫 1：装饰器与函数/类定义之间不得被注释或代码行分割（#32 精确签名）。"""
+
+    def test_no_comment_between_last_decorator_and_def(self):
+        offenders = []
+        for p in _py_files():
+            src = p.read_text(encoding="utf-8")
+            tree = ast.parse(src)
+            lines = src.splitlines()
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                    continue
+                if not node.decorator_list:
+                    continue
+                dec = node.decorator_list[-1]
+                dec_end = dec.end_lineno or dec.lineno
+                gap = lines[dec_end:node.lineno - 1]
+                # 空行放行（合法风格）；注释/代码行都是 #32 签名（注释不打断装饰器绑定）
+                bad = [i for i, l in enumerate(gap, dec_end + 1) if l.strip()]
+                if bad:
+                    offenders.append(
+                        f"{p}:{node.lineno} {type(node).__name__.lower()} {node.name} "
+                        f"decorator@{dec_end} 间隔行={bad}"
+                    )
+        self.assertEqual(
+            offenders, [],
+            "装饰器与定义之间被注释/代码分割（#32 同族）：\n" + "\n".join(offenders),
+        )
+
+
+class StaticBindingGuardTest(unittest.TestCase):
+    """守卫 2/3：@staticmethod 不得用实例属性/首参不得 self·cls；@classmethod 首参须 cls。"""
+
+    def test_staticmethod_and_classmethod_binding_sane(self):
+        offenders = []
+        for p in _py_files():
+            tree = ast.parse(p.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                decs = _decorator_names(node)
+                first = node.args.args[0].arg if node.args.args else None
+                uses_self = any(
+                    isinstance(n, ast.Attribute)
+                    and isinstance(n.value, ast.Name) and n.value.id == "self"
+                    for n in ast.walk(node)
+                )
+                if "staticmethod" in decs:
+                    if first in ("self", "cls"):
+                        offenders.append(
+                            f"{p}:{node.lineno} staticmethod 首参是 {first!r}（#32 签名） def {node.name}"
+                        )
+                    elif uses_self:
+                        offenders.append(
+                            f"{p}:{node.lineno} staticmethod 方法体引用 self 实例属性 def {node.name}"
+                        )
+                if "classmethod" in decs and first != "cls":
+                    offenders.append(
+                        f"{p}:{node.lineno} classmethod 首参是 {first!r}（应为 cls） def {node.name}"
+                    )
+        self.assertEqual(
+            offenders, [],
+            "静态/类方法绑定异常：\n" + "\n".join(offenders),
+        )
+
+
+class MockTargetGuardTest(unittest.TestCase):
+    """守卫 4：绑定敏感方法不得被 mock.patch.object 整体打桩（掩盖绑定回归，#32 教训）。"""
+
+    def test_binding_sensitive_methods_not_whole_mocked(self):
+        offenders = []
+        for p in sorted((REPO_ROOT / "tests").rglob("test_*.py")):
+            tree = ast.parse(p.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                fn = node.func
+                # mock.patch.object(obj, "NAME", ...) —— 第二位置参数为方法名
+                if not (isinstance(fn, ast.Attribute) and fn.attr == "object"):
+                    continue
+                if len(node.args) >= 2 and isinstance(node.args[1], ast.Constant):
+                    target = node.args[1].value
+                    if target in BINDING_SENSITIVE_METHODS:
+                        offenders.append(f"{p}:{node.lineno} mock.patch.object(..., {target!r})")
+        self.assertEqual(
+            offenders, [],
+            "绑定敏感方法被整体 mock（应下沉到方法体内依赖，见 docs/05 #139）：\n"
+            + "\n".join(offenders),
+        )

--- a/tests/test_binding_guard.py
+++ b/tests/test_binding_guard.py
@@ -178,3 +178,42 @@ class BindingDescriptorGuardTest(unittest.TestCase):
             offenders, [],
             "绑定敏感方法被静态/类方法绑定（#32 同族）：\n" + "\n".join(offenders),
         )
+
+
+class StaticMethodCallSiteGuardTest(unittest.TestCase):
+    """守卫 6：@staticmethod 必须经类名调用，不得经 self.<name>()（#139 C3 约定）。
+
+    经 self 调用静态方法当前合法（首参对得上），但改绑（加 self 参数/改签名）时
+    调用点与 mock 不对称即崩——统一类名调用让绑定错误在定义处即红。
+    abogus.py 例外：JS 移植风格内部大量 self 调用 static/classmethod（约 40 处），
+    绑定由真实调用测试兜底，白名单处理（docs/05 #139 C3）。
+    """
+
+    def test_staticmethods_called_via_class_not_self(self):
+        offenders = []
+        for p in _py_files():
+            if p.name == "abogus.py":
+                continue
+            tree = _parse(p.read_text(encoding="utf-8"))
+            for cls_node in (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)):
+                # 本类定义的 staticmethod 名
+                static_names = {
+                    n.name for n in cls_node.body
+                    if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and "staticmethod" in _decorator_names(n)
+                }
+                if not static_names:
+                    continue
+                for fn in (n for n in ast.walk(cls_node) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))):
+                    for call in ast.walk(fn):
+                        if not isinstance(call, ast.Call):
+                            continue
+                        func = call.func
+                        if (isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name)
+                                and func.value.id == "self" and func.attr in static_names):
+                            offenders.append(f"{p}:{call.lineno} self.{func.attr}()（应类名调用）")
+        self.assertEqual(
+            offenders, [],
+            "@staticmethod 经 self 调用（应改类名调用，见 docs/05 #139 C3）：\n"
+            + "\n".join(offenders),
+        )

--- a/tests/test_downloader_integration.py
+++ b/tests/test_downloader_integration.py
@@ -232,7 +232,7 @@ class GenericDownloaderTest(unittest.TestCase):
     def _patch_ydl(self, captured, info):
         import app.downloaders.generic_downloader as mod
 
-        with mock.patch.object(mod.CookieConfigManager, "get", return_value=""):
+        with mock.patch("app.services.cookie_manager.read_json", return_value={}):
             return mock.patch.object(mod.yt_dlp, "YoutubeDL", side_effect=_fake_ydl(captured, info))
 
     def test_download_result_contract(self):
@@ -251,7 +251,7 @@ class GenericDownloaderTest(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             captured = {}
-            with mock.patch.object(mod.CookieConfigManager, "get", return_value=""), \
+            with mock.patch("app.services.cookie_manager.read_json", return_value={}), \
                  mock.patch.object(mod.yt_dlp, "YoutubeDL",
                                    side_effect=_fake_ydl(captured, {"id": "g1", "title": "t"}, download_ok=False)):
                 with self.assertRaises(RuntimeError):

--- a/tests/test_downloader_robustness.py
+++ b/tests/test_downloader_robustness.py
@@ -93,16 +93,49 @@ class BcutBackoffTest(unittest.TestCase):
     """必剪轮询指数退避 1→2→4→5s 封顶；HTTP 调用带 timeout。"""
 
     def test_poll_backoff_sequence(self):
-        from app.transcriber.bcut import BcutTranscriber
+        from app.transcriber.bcut import (
+            API_COMMIT_UPLOAD,
+            API_CREATE_TASK,
+            API_REQ_UPLOAD,
+            BcutTranscriber,
+        )
 
         t = BcutTranscriber()
         states = iter([{"state": 0}, {"state": 0}, {"state": 0}, {"state": 4, "result": json.dumps({"utterances": []})}])
         sleeps = []
-        with mock.patch.object(t, "_upload"), \
-             mock.patch.object(t, "_create_task"), \
-             mock.patch.object(t, "_query_result", side_effect=lambda: next(states)), \
-             mock.patch("app.transcriber.bcut.time.sleep", side_effect=lambda s: sleeps.append(s)):
-            t.transcript("/tmp/fake.mp3")
+
+        def _resp(data, headers=None):
+            resp = mock.Mock()
+            resp.raise_for_status.return_value = None
+            resp.json.return_value = {"code": 0, "data": data}
+            resp.headers = headers if headers is not None else {}
+            return resp
+
+        def _post(url, *a, **k):
+            if url == API_REQ_UPLOAD:
+                return _resp({
+                    "size": 100, "in_boss_key": "k", "resource_id": "r",
+                    "upload_id": "u", "upload_urls": ["https://upload.example/p1"],
+                    "per_size": 1024,
+                })
+            if url == API_COMMIT_UPLOAD:
+                return _resp({"download_url": "https://dl.example/a.mp3"})
+            if url == API_CREATE_TASK:
+                return _resp({"task_id": "t1"})
+            raise AssertionError(f"未知 POST: {url}")
+
+        def _get(*a, **k):
+            return _resp(next(states))
+
+        with tempfile.TemporaryDirectory() as td:
+            fake = Path(td) / "fake.mp3"
+            fake.write_bytes(b"x" * 100)
+            # mock 下沉到 session 层（#139 C1）：真实走 _upload/_create_task/_query_result 绑定链
+            with mock.patch.object(t.session, "post", side_effect=_post), \
+                 mock.patch.object(t.session, "put", return_value=_resp(None, headers={"Etag": '"e1"'})), \
+                 mock.patch.object(t.session, "get", side_effect=_get), \
+                 mock.patch("app.transcriber.bcut.time.sleep", side_effect=lambda s: sleeps.append(s)):
+                t.transcript(str(fake))
         # i=0,1,2 → 1,2,4；第 4 次循环命中 state=4 直接 break
         self.assertEqual(sleeps, [1, 2, 4])
 
@@ -135,7 +168,7 @@ class GenericCookieTest(unittest.TestCase):
             ydl.extract_info.return_value = {"id": "vid1", "title": "t", "duration": 1, "ext": "m4a"}
             return ydl
 
-        with mock.patch.object(mod.CookieConfigManager, "get", return_value=cookie), \
+        with mock.patch("app.services.cookie_manager.read_json", return_value={"generic": cookie}), \
              mock.patch.object(mod, "get_data_dir", return_value=tempfile.gettempdir()), \
              mock.patch.object(mod.yt_dlp, "YoutubeDL", side_effect=_fake_ydl):
             mod.GenericDownloader().download("https://example-site.com/video")
@@ -158,7 +191,7 @@ class GenericCookieTest(unittest.TestCase):
     def test_no_cookie_file_left_on_disk(self):
         import app.downloaders.generic_downloader as mod
 
-        with mock.patch.object(mod.CookieConfigManager, "get", return_value="sessionid=abc123"), \
+        with mock.patch("app.services.cookie_manager.read_json", return_value={"generic": "sessionid=abc123"}), \
              mock.patch.object(mod, "get_data_dir", return_value=tempfile.gettempdir()):
             dl = mod.GenericDownloader()
             self.assertEqual(dl._get_cookie(), "sessionid=abc123")

--- a/tests/test_downloader_robustness.py
+++ b/tests/test_downloader_robustness.py
@@ -36,14 +36,14 @@ class KuaiShouFailureTest(unittest.TestCase):
 
     def test_no_cookies_raises(self):
         ks = self._mk()
-        with mock.patch.object(ks, "_extract_kuaishou_link", return_value="https://v.kuaishou.com/abc"), \
+        with mock.patch.object(KuaiShou, "_extract_kuaishou_link", return_value="https://v.kuaishou.com/abc"), \
              mock.patch.object(ks, "get_temp_cookies", return_value=None):
             with self.assertRaisesRegex(RuntimeError, "cookies 解析失败"):
                 ks.run("x")
 
     def test_no_photo_id_raises(self):
         ks = self._mk()
-        with mock.patch.object(ks, "_extract_kuaishou_link", return_value="https://v.kuaishou.com/abc"), \
+        with mock.patch.object(KuaiShou, "_extract_kuaishou_link", return_value="https://v.kuaishou.com/abc"), \
              mock.patch.object(ks, "get_temp_cookies", return_value="did=1"), \
              mock.patch.object(ks, "get_photo_id", return_value=None):
             with self.assertRaisesRegex(RuntimeError, "ID 解析失败"):
@@ -51,7 +51,7 @@ class KuaiShouFailureTest(unittest.TestCase):
 
     def test_no_details_raises_not_typeerror(self):
         ks = self._mk()
-        with mock.patch.object(ks, "_extract_kuaishou_link", return_value="https://v.kuaishou.com/abc"), \
+        with mock.patch.object(KuaiShou, "_extract_kuaishou_link", return_value="https://v.kuaishou.com/abc"), \
              mock.patch.object(ks, "get_temp_cookies", return_value="did=1"), \
              mock.patch.object(ks, "get_photo_id", return_value="ph1"), \
              mock.patch.object(ks, "get_video_details", return_value=None):
@@ -60,7 +60,7 @@ class KuaiShouFailureTest(unittest.TestCase):
 
     def test_empty_data_raises(self):
         ks = self._mk()
-        with mock.patch.object(ks, "_extract_kuaishou_link", return_value="https://v.kuaishou.com/abc"), \
+        with mock.patch.object(KuaiShou, "_extract_kuaishou_link", return_value="https://v.kuaishou.com/abc"), \
              mock.patch.object(ks, "get_temp_cookies", return_value="did=1"), \
              mock.patch.object(ks, "get_photo_id", return_value="ph1"), \
              mock.patch.object(ks, "get_video_details", return_value={"data": None}):
@@ -70,7 +70,7 @@ class KuaiShouFailureTest(unittest.TestCase):
     def test_success_returns_data(self):
         ks = self._mk()
         payload = {"data": {"visionVideoDetail": {"photo": {"id": "ph1"}}}}
-        with mock.patch.object(ks, "_extract_kuaishou_link", return_value="https://v.kuaishou.com/abc"), \
+        with mock.patch.object(KuaiShou, "_extract_kuaishou_link", return_value="https://v.kuaishou.com/abc"), \
              mock.patch.object(ks, "get_temp_cookies", return_value="did=1"), \
              mock.patch.object(ks, "get_photo_id", return_value="ph1"), \
              mock.patch.object(ks, "get_video_details", return_value=payload):

--- a/tests/test_gpt_resilience.py
+++ b/tests/test_gpt_resilience.py
@@ -45,7 +45,7 @@ class QuotaErrorTest(unittest.TestCase):
     def test_quota_failure_single_attempt(self):
         gpt = _gpt()
         with mock.patch.object(
-            gpt, "_do_create", side_effect=RuntimeError("insufficient_user_quota")
+            gpt.client.chat.completions, "create", side_effect=RuntimeError("insufficient_user_quota")
         ) as m_do_create:
             with self.assertRaises(RuntimeError):
                 gpt._chat_completion_create([{"role": "user", "content": "x"}])
@@ -59,7 +59,7 @@ class MergeCancelTest(unittest.TestCase):
         gpt = _gpt()
         cancel = threading.Event()
         cancel.set()
-        with mock.patch.object(gpt, "_chat_completion_create") as m:
+        with mock.patch.object(gpt.client.chat.completions, "create") as m:
             with self.assertRaises(TaskCancelledError):
                 gpt._merge_partials(["partial-1", "partial-2"], None, None, cancel_event=cancel)
         m.assert_not_called()
@@ -67,7 +67,7 @@ class MergeCancelTest(unittest.TestCase):
     def test_merge_proceeds_without_cancel(self):
         gpt = _gpt()
         with mock.patch.object(
-            gpt, "_chat_completion_create",
+            gpt.client.chat.completions, "create",
             return_value=mock.Mock(choices=[mock.Mock(
                 message=mock.Mock(content="合并结果"), finish_reason="stop")]),
         ) as m:

--- a/tests/test_integration_transcribe.py
+++ b/tests/test_integration_transcribe.py
@@ -1,0 +1,96 @@
+"""真实转写集成冒烟（docs/05 #139 C2）——默认跳过，CI 手动 job / 本地显式触发。
+
+全库唯一的「转写引擎实例化 + 模型加载 + 推理」真实执行路径：其余测试都在
+get_transcriber 或更上层打桩（#32 回归测试也只到 get_transcriber）。这里补上
+引擎类内部（_load_model / transcript 绑定）的真实执行，绑定类回归在引擎层
+不再测试与 CI 双双失明。
+
+触发：`VIDEONOTE_RUN_INTEGRATION=1 uv run pytest tests/test_integration_transcribe.py -q`
+引擎：darwin → mlx-whisper（tiny），其余平台 → fast-whisper（tiny）。
+模型缺失/加载失败 → skip 而非 fail（集成冒烟锦上添花，不拦发布）。
+"""
+import math
+import os
+import platform
+import struct
+import wave
+from pathlib import Path
+
+import pytest
+
+from app.models.transcriber_model import TranscriptResult
+from app.transcriber.transcriber_provider import get_transcriber
+
+pytestmark = pytest.mark.integration
+
+RUN_GATE = os.environ.get("VIDEONOTE_RUN_INTEGRATION") == "1"
+
+
+def _synthesize_tone(path, seconds: float = 1.0, freq: int = 440) -> None:
+    """合成 1s 16kHz mono 正弦波 wav（whisper 可直接消费，无需 ffmpeg）。"""
+    rate = 16000
+    with wave.open(str(path), "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(rate)
+        w.writeframes(b"".join(
+            struct.pack("<h", int(32767 * 0.3 * math.sin(2 * math.pi * freq * t / rate)))
+            for t in range(int(rate * seconds))
+        ))
+
+
+def _real_model_dir() -> str:
+    """测试隔离把 VIDEONOTE_MODEL_DIR 指到 /tmp（models 空）；集成冒烟读真实用户缓存。
+
+    get_model_dir 每次调用读 env（path_helper.py:26），测试内覆盖即可，无需打桩。
+    """
+    candidates = [
+        str(Path(__file__).resolve().parents[1] / "data" / "models"),  # 源码模式
+        str(Path.home() / ".local" / "share" / "videonote-mcp" / "models"),  # 安装模式
+    ]
+    for c in candidates:
+        if (Path(c) / "whisper").exists():
+            return c
+    return candidates[0]
+
+
+def _load_any_transcriber():
+    """按候选顺序加载：darwin 优先 mlx-whisper（tiny），兜底 fast-whisper（small）。
+
+    都不可用（模型未下载/加载失败）→ skip 而非 fail——集成冒烟锦上添花，不拦发布。
+    """
+    candidates = []
+    if platform.system() == "Darwin":
+        candidates.append(("mlx-whisper", "tiny"))
+    candidates.append(("fast-whisper", "small"))
+    prev = os.environ.get("VIDEONOTE_MODEL_DIR")
+    os.environ["VIDEONOTE_MODEL_DIR"] = _real_model_dir()
+    try:
+        last = None
+        for engine, size in candidates:
+            try:
+                return get_transcriber(transcriber_type=engine, model_size=size)
+            except Exception as exc:  # noqa: BLE001 —— 模型不可用属环境问题，继续尝试候选
+                last = exc
+        pytest.skip(f"无可用转写模型（{candidates}）: {last}")
+    finally:
+        if prev is None:
+            os.environ.pop("VIDEONOTE_MODEL_DIR", None)
+        else:
+            os.environ["VIDEONOTE_MODEL_DIR"] = prev
+
+
+@pytest.mark.skipif(
+    not RUN_GATE,
+    reason="集成冒烟默认跳过：VIDEONOTE_RUN_INTEGRATION=1 触发（docs/05 #139 C2）",
+)
+def test_real_transcribe_roundtrip(tmp_path):
+    audio = tmp_path / "tone.wav"
+    _synthesize_tone(audio)
+    transcriber = _load_any_transcriber()
+    # 直调引擎 transcript（不经 pipeline 的空转写守卫）：正弦波无语音内容，
+    # 但引擎构造 + 模型加载 + 推理的真实绑定链必须跑通（#139 C2 的目标）
+    result = transcriber.transcript(str(audio))
+    assert isinstance(result, TranscriptResult)
+    assert isinstance(result.language, str)
+    assert isinstance(result.segments, list)

--- a/tests/test_material_mode.py
+++ b/tests/test_material_mode.py
@@ -15,6 +15,7 @@ import base64
 import json
 import shutil
 import sys
+from contextlib import nullcontext
 from pathlib import Path
 from unittest import mock
 
@@ -197,8 +198,7 @@ def test_skip_download_media_cache_miss_clears_audio_path():
         video_id="BV1xx411c7mD",
         raw_info={},
     )
-    with mock.patch("app.services.note.note_cache.lookup_media", return_value=None), \
-         mock.patch.object(gen, "_update_status"):
+    with mock.patch("app.services.note.note_cache.lookup_media", return_value=None):
         audio = gen._download_media(
             downloader=fake_downloader,
             video_url="https://www.bilibili.com/video/BV1xx411c7mD",
@@ -250,8 +250,7 @@ def test_skip_download_keeps_real_local_path():
         video_id=None,
         raw_info={},
     )
-    with mock.patch("app.services.note.note_cache.lookup_media", return_value=None), \
-         mock.patch.object(gen, "_update_status"):
+    with mock.patch("app.services.note.note_cache.lookup_media", return_value=None):
         audio = gen._download_media(
             downloader=fake_downloader,
             video_url=local_path,
@@ -294,7 +293,7 @@ def test_skip_download_media_cache_hit_reuses_real_file():
     )
     with mock.patch(
         "app.services.note.note_cache.lookup_media", return_value="/cache/real.mp3"
-    ), mock.patch.object(gen, "_update_status"):
+    ):
         audio = gen._download_media(
             downloader=fake_downloader,
             video_url="https://www.bilibili.com/video/BV1xx411c7mD",
@@ -348,7 +347,7 @@ def test_audio_cache_none_file_path_treated_as_stale():
         video_id="BV1xx411c7mD",
         raw_info={},
     )
-    with mock.patch.object(gen, "_update_status"):
+    with nullcontext():
         audio = gen._download_media(
             downloader=fake_downloader,
             video_url="https://www.bilibili.com/video/BV1xx411c7mD",
@@ -401,8 +400,7 @@ def test_format_screenshot_forces_video_download():
         video_id="BV1xx411c7mD",
         raw_info={},
     )
-    with mock.patch.object(gen, "_update_status"), \
-         mock.patch.object(gen, "_get_downloader", return_value=fake_dl), \
+    with mock.patch("app.services.note._new_downloader", return_value=fake_dl), \
          mock.patch.object(note_mod, "VideoReader") as m_reader, \
          mock.patch.object(note_mod, "_extract_audio_from_video",
                            return_value=str(task_dir / "raw" / "a.mp3")), \

--- a/tests/test_note_cache.py
+++ b/tests/test_note_cache.py
@@ -337,7 +337,7 @@ class GenerateIntegrationTest(unittest.TestCase):
         gen = self._gen()
         downloader = _fake_downloader("abcDEF12345")
         with mock.patch.object(gen, "_get_downloader", return_value=downloader):
-            with mock.patch.object(gen, "_init_transcriber") as init_tr:
+            with mock.patch("app.services.note.get_transcriber") as init_tr:
                 result = gen.generate(
                     video_url=self.YT_URL, platform="youtube",
                     task_id="cachehit00001", material_only=True,
@@ -358,7 +358,7 @@ class GenerateIntegrationTest(unittest.TestCase):
             "segments": [{"start": 0, "end": 1, "text": "fresh"}],
         }
         with mock.patch.object(gen, "_get_downloader", return_value=downloader):
-            with mock.patch.object(gen, "_init_transcriber") as init_tr:
+            with mock.patch("app.services.note.get_transcriber") as init_tr:
                 # 无字幕视频：generate 主路径已试过 downloader.download_subtitles（None），
                 # _get_transcript 走 skip_subtitle=True → pipeline.fetch_subtitles 不得再调
                 # （重复 API 调用，#123 B1）
@@ -446,7 +446,7 @@ class GenerateIntegrationTest(unittest.TestCase):
             }
             gen = self._gen()
             with mock.patch.object(gen, "_get_downloader", return_value=downloader):
-                with mock.patch.object(gen, "_init_transcriber"):
+                with mock.patch("app.services.note.get_transcriber"):
                     with mock.patch.object(note_pipeline, "fetch_subtitles", return_value=None):
                         with mock.patch.object(note_pipeline, "transcribe_audio", return_value=transcript_dict):
                             gen.generate(
@@ -458,7 +458,7 @@ class GenerateIntegrationTest(unittest.TestCase):
 
             gen2 = self._gen()
             with mock.patch.object(gen2, "_get_downloader", return_value=downloader):
-                with mock.patch.object(gen2, "_init_transcriber"):
+                with mock.patch("app.services.note.get_transcriber"):
                     result2 = gen2.generate(
                         video_url=self.YT_URL, platform="youtube",
                         task_id="media000002", material_only=True,

--- a/tests/test_note_cache.py
+++ b/tests/test_note_cache.py
@@ -336,7 +336,7 @@ class GenerateIntegrationTest(unittest.TestCase):
         }, ensure_ascii=False))
         gen = self._gen()
         downloader = _fake_downloader("abcDEF12345")
-        with mock.patch.object(gen, "_get_downloader", return_value=downloader):
+        with mock.patch("app.services.note._new_downloader", return_value=downloader):
             with mock.patch("app.services.note.get_transcriber") as init_tr:
                 result = gen.generate(
                     video_url=self.YT_URL, platform="youtube",
@@ -357,7 +357,7 @@ class GenerateIntegrationTest(unittest.TestCase):
             "language": "zh", "full_text": "fresh",
             "segments": [{"start": 0, "end": 1, "text": "fresh"}],
         }
-        with mock.patch.object(gen, "_get_downloader", return_value=downloader):
+        with mock.patch("app.services.note._new_downloader", return_value=downloader):
             with mock.patch("app.services.note.get_transcriber") as init_tr:
                 # 无字幕视频：generate 主路径已试过 downloader.download_subtitles（None），
                 # _get_transcript 走 skip_subtitle=True → pipeline.fetch_subtitles 不得再调
@@ -395,7 +395,7 @@ class GenerateIntegrationTest(unittest.TestCase):
             "language": "zh", "full_text": "fresh",
             "segments": [{"start": 0, "end": 1, "text": "fresh"}],
         }
-        with mock.patch.object(gen, "_get_downloader", return_value=downloader):
+        with mock.patch("app.services.note._new_downloader", return_value=downloader):
             with mock.patch("app.services.note.get_transcriber", return_value=fake_transcriber) as gt:
                 with mock.patch.object(
                     note_pipeline, "fetch_subtitles",
@@ -421,13 +421,20 @@ class GenerateIntegrationTest(unittest.TestCase):
             with mock.patch.object(
                 note_pipeline, "fetch_subtitles",
                 side_effect=AssertionError("skip_subtitle=True 时不应调字幕 API"),
-            ), mock.patch.object(gen, "_transcribe_audio", return_value=None) as m_tr:
+            ), mock.patch("app.services.note.get_transcriber", return_value=mock.Mock()) as gt, \
+               mock.patch.object(note_pipeline, "transcribe_audio", return_value={
+                   "language": "zh", "full_text": "fresh",
+                   "segments": [{"start": 0, "end": 1, "text": "fresh"}],
+               }) as m_tr:
                 out = gen._get_transcript(
                     downloader, "https://example.com/v", "/no/audio", cache_file,
                     TaskStatus.TRANSCRIBING, "t1", skip_subtitle=True,
                 )
-        self.assertIsNone(out)
+        # mock 下沉到依赖层（#139 C1）：真实 _transcribe_audio + _init_transcriber 绑定链跑通
+        gt.assert_called_once()
         m_tr.assert_called_once()
+        self.assertIsNotNone(out)
+        self.assertEqual(out.full_text, "fresh")
 
     def test_miss_promotes_media_and_hit_copies_audio(self):
         # run1 完整下载（真实音频文件）→ promote 出媒体缓存；run2 命中 → audio_path 指向
@@ -445,7 +452,7 @@ class GenerateIntegrationTest(unittest.TestCase):
                 "segments": [{"start": 0, "end": 1, "text": "fresh"}],
             }
             gen = self._gen()
-            with mock.patch.object(gen, "_get_downloader", return_value=downloader):
+            with mock.patch("app.services.note._new_downloader", return_value=downloader):
                 with mock.patch("app.services.note.get_transcriber"):
                     with mock.patch.object(note_pipeline, "fetch_subtitles", return_value=None):
                         with mock.patch.object(note_pipeline, "transcribe_audio", return_value=transcript_dict):
@@ -457,7 +464,7 @@ class GenerateIntegrationTest(unittest.TestCase):
             self.assertTrue((media_dir / "abcDEF12345.mp3").exists())
 
             gen2 = self._gen()
-            with mock.patch.object(gen2, "_get_downloader", return_value=downloader):
+            with mock.patch("app.services.note._new_downloader", return_value=downloader):
                 with mock.patch("app.services.note.get_transcriber"):
                     result2 = gen2.generate(
                         video_url=self.YT_URL, platform="youtube",

--- a/tests/test_outline.py
+++ b/tests/test_outline.py
@@ -44,12 +44,12 @@ def _captured_prompts(gpt, segments, title="测试视频"):
     source = GPTSource(title=title, segment=segments, tags="", checkpoint_key=None)
     captured = []
 
-    def capture(messages):
-        captured.append(messages[0]["content"])
+    def capture(**kwargs):
+        captured.append(kwargs["messages"][0]["content"])
         return mock.Mock(choices=[mock.Mock(
             message=mock.Mock(content="## 结果"), finish_reason="stop")])
 
-    with mock.patch.object(gpt, "_chat_completion_create", side_effect=capture):
+    with mock.patch.object(gpt.client.chat.completions, "create", side_effect=capture):
         gpt.summarize(source)
     return captured
 
@@ -125,14 +125,16 @@ class TestOutlineInjection:
                 title="t", segment=_long_segments(4), tags="", checkpoint_key="ck")
             captured = []
 
-            def capture(messages):
-                captured.append(messages[0]["content"])
+            def capture(**kwargs):
+                captured.append(kwargs["messages"][0]["content"])
                 return mock.Mock(choices=[mock.Mock(
                     message=mock.Mock(content="## 第二章\n内容"), finish_reason="stop")])
 
+            # _load_checkpoint 保留方法级 mock（checkpoint 内容与签名哈希耦合，下沉成本高）；
+            # 其绑定由 test_binding_guard 守卫 5（descriptor 断言）覆盖（docs/05 #139 C1）
             with mock.patch.object(gpt, "_load_checkpoint",
                                    return_value={"partials": ["## 第一章\n内容"], "phase": "summarize"}), \
-                 mock.patch.object(gpt, "_chat_completion_create", side_effect=capture):
+                 mock.patch.object(gpt.client.chat.completions, "create", side_effect=capture):
                 result = gpt.summarize(source)
 
             assert "第二章" in result  # merge 产物（capture 固定返回该值）

--- a/uv.lock
+++ b/uv.lock
@@ -4021,7 +4021,7 @@ wheels = [
 
 [[package]]
 name = "videonote"
-version = "0.1.17"
+version = "0.1.18"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.17"
+__version__ = "0.1.18"


### PR DESCRIPTION
## 发布内容（8 commits）

**第 18 轮专项扫描 #139 实施**（#32 修复后用户要求全库扫同类——结论：无已存在 bug，但防回归机制缺失，本轮补齐）：

1. **批次 1**（a3bcac4）：绑定守卫测试 4 道（装饰器间隔 / staticmethod 用 self / classmethod 缺 cls / mock 目标白名单）
2. **批次 2**（c62a5e8）：死代码清理——whisper 死静态方法、`_get_or_build_transcriber` 改名、异常注解、三处死注释
3. **批次 4**（97ed5ef）：mock 下沉 16 处 + 守卫 5（descriptor 断言）
4. **批次 5**（87f1d6f）：staticmethod 类名调用 16 处 + 守卫 6
5. **批次 6**（76dd7d3）：真实转写集成冒烟（全库第一条真实转写路径，本地 fast-whisper small 验证通过）+ CI 手动 job
6. docs 登记（f5f3412 / d0ad1bc）+ 版本 bump 0.1.18（d2f86c9）

## 验证

- 714 passed + 1 skipped（integration 默认跳过）+ ruff F/I-clean
- 守卫体系 6 道：#32 的四个签名 + descriptor 断言 + 类名调用约定
- 版本四处一致：pyproject / `__init__` / plugin.json / tag