### PR TITLE
feat: 小宇宙登录默认扫码（v0.1.20 同版补丁）

### DIFF
--- a/docs/00-新手上路.md
+++ b/docs/00-新手上路.md
@@ -51,7 +51,7 @@ URL / file:// / 本地路径
 ### 验证三件套（每次改动后跑）
 
 ```bash
-uv run pytest -q            # 全量 802 测试（当前基线）
+uv run pytest -q            # 全量 805 测试（当前基线）
 uv run ruff check --select F .   # F 类（语法/未定义）——CI 门槛
 uv run ruff check --select I .   # import 排序——CI 门槛
 ```
@@ -108,7 +108,7 @@ docs: 回填 #N commit hash（<hash>）
 
 ## 六、当前状态（2026-08-22 基线）
 
-- **10 工具**（精确名单在 `ci.yml`；#135/#136 精简自 39，再 #138 16→10）、**802 tests**、ruff F/I-clean。
+- **10 工具**（精确名单在 `ci.yml`；#135/#136 精简自 39，再 #138 16→10）、**805 tests**、ruff F/I-clean。
 - 最近一轮：`docs/05` **#142 安全扫描收尾**（MCP 本地文件/危险操作边界开关 + 模型 revision 固定 + B站弹幕 XML 安全解析 + YouTube EJS 开关 + MD5 FIPS 兼容；详见 05）。上一轮 #141（#140 安全复扫）。
 - **死代码纪律**：先跑 AST import 图 + 名字引用计数双扫描再动手；`from X import Y` 的 Y 是字符串不是 Name 节点（v1 扫描漏检过）；删函数后 grep 全仓（含 tests/CLI）确认零引用，VENDOR.md 同步，留意 dangling 装饰器/finally。
 - **未实施的开放候选**（#133 登记「建议后续」，见 `05` 尾部）：A2 固定 tmp+0644 写盘收尾、B4 diarize normalize 残留 wav、B5 local/kuaishou 转码不响应取消、B6 Provider DAO 吞异常、C5 全局 /tmp 断言、C6 conftest setdefault 不对称、C7 Dockerfile 缺 skills、C8 测试硬编码 /tmp、C9 单文件直跑、C10 CLI download choices 缺档；#132 C 组 6 项（C3/C5/C6/C7/C11/C12）。

--- a/docs/04-使用手册.md
+++ b/docs/04-使用手册.md
@@ -94,7 +94,7 @@ videonote transcriber download small --engine mlx-whisper  # 下载 mlx-whisper�
 # B 站：优先用平台字幕（含 AI 字幕）跳过语音识别；AI 字幕需登录态
 videonote login bilibili     # 扫码登录，二维码渲染进终端/会话，自动保存 SESSDATA
 # 小宇宙：优先用官方文稿跳过本地 ASR（47 分钟单集否则会转写很久）
-videonote login xiaoyuzhou   # 粘贴 x-jike-access-token + refresh-token
+videonote login xiaoyuzhou   # 扫码登录（小宇宙 App）；`--token` 改粘贴
 videonote transcriber set groq                        # 切云端
 ```
 
@@ -123,7 +123,7 @@ get_config()                         # transcriber 段：当前引擎/尺寸/就
 ```text
 # Cookie / token 不进 MCP 工具参数（会进对话上游）——一律走本会话终端：
 ! videonote login bilibili        # 扫码登录，自动保存 SESSDATA
-! videonote login xiaoyuzhou      # 粘贴 x-jike-access-token（建议同时给 refresh-token）
+! videonote login xiaoyuzhou      # 扫码登录（小宇宙 App）；`--token` 改粘贴
 # 或 setup 向导的 Cookie / 小宇宙登录步骤
 # 非交互：videonote cookie set xiaoyuzhou 'x-jike-access-token=...; x-jike-refresh-token=...'
 ```

--- a/docs/06-执行进度.md
+++ b/docs/06-执行进度.md
@@ -351,3 +351,4 @@
 ## 小宇宙官方文稿（2026-08-30）
 
 - [x] 小宇宙升为一等平台：`detect_platform` 识别 `xiaoyuzhoufm.com`，官方文稿 `episode-transcript/get` 优先（需 `x-jike-access-token`，refresh 自动续期），未登录回退 yt-dlp+ASR。CLI `login xiaoyuzhou` / `cookie set`，凭证不进 MCP。**802 passed + ruff F/I-clean**。
+- [x] 小宇宙登录默认扫码（官网 `qrcode/create` + `qrcode/login`），`--token` 保留粘贴；凭证不打印。**805 passed + ruff F/I-clean**。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -781,3 +781,10 @@ v0.1.1 → v0.1.2 的主要变更（详见下方各「维护」节点块；稳�
 - **登录态**：access token 约 2 小时过期，配 refresh token 后 401 自动续期并写回 `downloader.json`。凭证走 `videonote login xiaoyuzhou` / `cookie set`，不进 MCP 工具。
 - **回退**：未登录或该期无文稿 → yt-dlp 下音频 + 本地 ASR（原 generic 行为）。
 - **文档 / Skill / VENDOR** 同步；改 Skill 后需刷新插件。
+
+## 小宇宙扫码登录（2026-08-30 · `login xiaoyuzhou` 默认扫码，802→805 tests）
+
+- **默认扫码**：`videonote login xiaoyuzhou` 走官网统一登录 `web-api.xiaoyuzhoufm.com/v1/auth/qrcode/create` + `/login`（clientId `xyz-web`），终端 ASCII 二维码，小宇宙 App 扫确认后保存 x-jike token。
+- **后备**：`--token` 仍可粘贴 access/refresh；非交互继续 `cookie set`。凭证不进 MCP / 不打印明文。
+- **setup 向导**「小宇宙登录」改为扫码。
+- Skill / 04 / troubleshooting 同步；改 Skill 后需刷新插件。

--- a/skills/videonote/SKILL.md
+++ b/skills/videonote/SKILL.md
@@ -18,7 +18,7 @@ description: 用 VideoNote-Mcp 的 MCP 工具把视频链接/本地视频（B站
      要全出笔记 → 一条 `batch_generate_notes(url)` 服务端逐个排队（省去逐条 subagent，见规则 2）。
 5. 长视频 / 首次使用 / 最近改过转写引擎 → `health_check(url)` 体检（ffmpeg/磁盘/转写器/供应商 key，`ok=false` 先修）。
 6. 直接 `generate_note(video_url)`（`provider_id` 可省略）。参数不传 = setup / userConfig 默认。
-   - **转写素材自动优先平台官方字幕**（YouTube/B 站人工+自动字幕 / 小宇宙官方文稿）——有官方字幕的视频不会走本地转写引擎；无字幕/获取失败才下载音轨转写。用户问「为什么走/没走转写引擎」先看该视频有无官方字幕。小宇宙官方文稿需用户先 `! videonote login xiaoyuzhou`。
+   - **转写素材自动优先平台官方字幕**（YouTube/B 站人工+自动字幕 / 小宇宙官方文稿）——有官方字幕的视频不会走本地转写引擎；无字幕/获取失败才下载音轨转写。用户问「为什么走/没走转写引擎」先看该视频有无官方字幕。小宇宙官方文稿需用户先 `! videonote login xiaoyuzhou`（终端扫码）。
 7. **`task(task_id)` 轮询**到 SUCCESS / FAILED / CANCELLED。等待中可用 `stage` / `elapsed_secs` 报进度（如「转写中，已 3 分钟」）。
 8. 呈现 `result.markdown`（要点 + 章节 + 原文链接）。用户要细节再用 `task(task_id, action="transcript")`（默认前 50 段；全文 `segment_range="all"`）。
 9. **不要主动问「要不要后续优化」**。用户要精修再读笔记 + 转写改。

--- a/skills/videonote/reference/tools.md
+++ b/skills/videonote/reference/tools.md
@@ -145,7 +145,7 @@
 | 切本地转写 | `! videonote transcriber set --engine fast-whisper --size small` + `! videonote transcriber download small` |
 | 切云端转写 | `! videonote transcriber set --engine groq`（groq key 用 CLI 填） |
 | B 站登录/AI 字幕/评论 | 用户在本会话 `! videonote login bilibili` 扫码（二维码渲染进会话终端，存 SESSDATA） |
-| 小宇宙官方文稿 | 用户在本会话 `! videonote login xiaoyuzhou` 粘贴 x-jike-access-token（建议同时给 refresh-token）；未登录会回退本地下载+ASR，长节目会非常慢 |
+| 小宇宙官方文稿 | 用户在本会话 `! videonote login xiaoyuzhou` 用小宇宙 App 扫码（或 `--token` 粘贴）；未登录会回退本地下载+ASR，长节目会非常慢 |
 | 本地文件 | `generate_note(video_url="file:///绝对/路径/foo%20bar.mp4")` 或普通路径，`platform` 可省略 |
 | 视频理解默认（setup ③） | 用户说「用默认」/ 全自动模式时不传 `video_understanding`/`video_interval` 即套用（默认关/6s） |
 | 评论/弹幕整合默认（setup ③） | 用户说「用默认」/ 全自动模式时不传 `include_comments`/`comments_limit` 即套用（默认关/20 条） |

--- a/skills/videonote/reference/troubleshooting.md
+++ b/skills/videonote/reference/troubleshooting.md
@@ -14,7 +14,7 @@
 | 任务 FAILED、message 是 Python 异常原文（如 `missing 1 required positional argument: 'self'` / `TypeError`） | 疑似 #32 同族绑定回归（装饰器误绑实例方法）——仓库已加守卫测试 `tests/test_binding_guard.py` 拦截；升级到最新版（`uvx videonote@latest` 会话自动取新版），仍现则报 issue 附完整 FAILED message |
 | B 站下载报 `fatal` / playurl 412 | 已修复（yt-dlp fatal 透传）；仍失败则让用户 `videonote login bilibili`（扫码存 SESSDATA）后重试 |
 | 想用 B 站 **AI 字幕**跳过语音识别 | 引导用户跑 `videonote login bilibili`（扫码自动存 SESSDATA）。AI 字幕需登录态；`raw_info.subtitles={}` 只反映手动 CC，AI 字幕在 automatic_captions |
-| 小宇宙长时间卡在转写 / 想用官方文稿 | 未配登录态会走本地下载+ASR。引导用户 `! videonote login xiaoyuzhou`（粘贴 x-jike-access-token，建议带 refresh-token）后重试；`inspect_video` 应返回 `platform:"xiaoyuzhou"` |
+| 小宇宙长时间卡在转写 / 想用官方文稿 | 未配登录态会走本地下载+ASR。引导用户 `! videonote login xiaoyuzhou`（终端扫码，小宇宙 App 确认）后重试；扫不了再用 `--token`。`inspect_video` 应返回 `platform:"xiaoyuzhou"` |
 | 整合评论/弹幕时评论拿不到 | 未配 B 站 SESSDATA —— 引导用户 `videonote login bilibili`；抓取失败**不阻断**笔记生成（跳过该部分） |
 | 其他平台（非内置平台） | `inspect_video` 返回 `platform:"generic"` → 自动走 **yt-dlp 通用提取**（覆盖 1800+ 站点）；若也失败任务报错 → Agent 接手：WebFetch/浏览器解析视频源后 `generate_note(video_url="/绝对/路径/x.mp4", platform="local")` |
 | generic 下载报需登录/JS 渲染 | 该站点 yt-dlp 无法直接提取 —— Agent 用 WebFetch/浏览器处理登录/验证，或让用户 `videonote setup` 向导里配「平台 Cookie」后重试 |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,11 +15,13 @@ import json
 import os
 import subprocess
 import sys
+import time
 import uuid
 from pathlib import Path
 from unittest import mock
 
 import pytest
+import requests
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -332,8 +334,37 @@ class TestLoginYoutube:
         assert "xiaoyuzhou" in err
 
 
+class _FakeXyzResp:
+    def __init__(self, status_code, json_data, headers=None, content=b"{}"):
+        self.status_code = status_code
+        self._json = json_data
+        self.headers = headers or {}
+        self.content = content if json_data is None else b"{}"
+        self.cookies = {}
+
+    def json(self):
+        if self._json is None:
+            raise ValueError("not json")
+        return self._json
+
+
+class _FakeXyzSession:
+    def __init__(self, posts):
+        self.headers = {}
+        self.cookies = mock.Mock()
+        self.cookies.get.return_value = ""
+        self._posts = list(posts)
+        self.calls = []
+
+    def post(self, url, json=None, timeout=None):
+        self.calls.append((url, json))
+        if not self._posts:
+            raise AssertionError(f"unexpected POST {url}")
+        return self._posts.pop(0)
+
+
 class TestLoginXiaoyuzhou:
-    def test_saves_tokens_and_verifies(self, capsys, monkeypatch):
+    def test_token_flag_saves_and_verifies(self, capsys, monkeypatch):
         import InquirerPy.inquirer as inq_mod
 
         def _secret(message="", **kwargs):
@@ -346,7 +377,7 @@ class TestLoginXiaoyuzhou:
             "app.downloaders.xiaoyuzhou_subtitle.verify_xiaoyuzhou_login",
             lambda: "",
         )
-        cli._login_xiaoyuzhou([])
+        cli._login_xiaoyuzhou(["--token"])
         out = _cli_out(capsys)
         assert "登录态有效" in out
         assert "acc-tok" not in out
@@ -358,7 +389,7 @@ class TestLoginXiaoyuzhou:
         capsys.readouterr()
         cli._cookie_cli(["clear", "xiaoyuzhou"])
 
-    def test_empty_access_cancels(self, capsys, monkeypatch):
+    def test_token_empty_access_cancels(self, capsys, monkeypatch):
         import InquirerPy.inquirer as inq_mod
 
         def _secret(message="", **kwargs):
@@ -367,8 +398,67 @@ class TestLoginXiaoyuzhou:
             return box
 
         monkeypatch.setattr(inq_mod, "secret", _secret)
-        cli._login_xiaoyuzhou([])
+        cli._login_xiaoyuzhou(["--token"])
         assert "已取消" in _cli_out(capsys)
+
+    def test_qr_saves_tokens_without_printing_them(self, capsys, monkeypatch):
+        create = _FakeXyzResp(
+            200,
+            {"id": "qr-id-1", "url": "https://h5.xiaoyuzhoufm.com/oauth?qrcode_id=qr-id-1"},
+        )
+        wait = _FakeXyzResp(200, {"status": "WAITTING"})
+        scanned = _FakeXyzResp(200, {"status": "SCANNED"})
+        confirmed = _FakeXyzResp(
+            200,
+            {"status": "CONFIRMED"},
+            headers={
+                "x-jike-access-token": "acc-from-qr",
+                "x-jike-refresh-token": "ref-from-qr",
+            },
+        )
+        session = _FakeXyzSession([create, wait, scanned, confirmed])
+        monkeypatch.setattr(requests, "Session", lambda: session)
+        monkeypatch.setattr(time, "sleep", lambda *_: None)
+        monkeypatch.setattr(cli, "_print_ascii_qr", lambda data: print(f"QR:{data}", file=sys.stdout))
+        monkeypatch.setattr(
+            "app.downloaders.xiaoyuzhou_subtitle.verify_xiaoyuzhou_login",
+            lambda: "",
+        )
+        monkeypatch.setattr("builtins.input", lambda *_: "")
+        cli._login_xiaoyuzhou([])
+        out = _cli_out(capsys)
+        assert "已保存小宇宙登录态" in out
+        assert "已扫码" in out
+        assert "acc-from-qr" not in out
+        assert "ref-from-qr" not in out
+        capsys.readouterr()
+        cli._cookie_cli(["list"])
+        listed = _cli_out(capsys)
+        assert "xiaoyuzhou" in listed
+        assert "acc-from-qr" not in listed
+        capsys.readouterr()
+        cli._cookie_cli(["clear", "xiaoyuzhou"])
+
+    def test_qr_expired_code_21(self, capsys, monkeypatch):
+        create = _FakeXyzResp(
+            200,
+            {"id": "qr-id-2", "url": "https://h5.xiaoyuzhoufm.com/oauth?qrcode_id=qr-id-2"},
+        )
+        expired = _FakeXyzResp(401, {"code": 21, "toast": "二维码已失效"})
+        session = _FakeXyzSession([create, expired])
+        monkeypatch.setattr(requests, "Session", lambda: session)
+        monkeypatch.setattr(time, "sleep", lambda *_: None)
+        monkeypatch.setattr(cli, "_print_ascii_qr", lambda data: None)
+        cli._login_xiaoyuzhou([])
+        assert "已过期" in _cli_out(capsys)
+
+    def test_qr_create_failure_exits(self, capsys, monkeypatch):
+        session = _FakeXyzSession([_FakeXyzResp(400, {"toast": "参数错误"})])
+        monkeypatch.setattr(requests, "Session", lambda: session)
+        with pytest.raises(SystemExit) as ei:
+            cli._login_xiaoyuzhou([])
+        assert ei.value.code == 1
+        assert "生成二维码失败" in capsys.readouterr().err
 
 
 class TestExportCli:

--- a/videonote_mcp/cli.py
+++ b/videonote_mcp/cli.py
@@ -629,7 +629,7 @@ def _wizard_other(inq) -> None:
                 message="选择要配置的项（← 返回）",
                 choices=[
                     {"name": "B 站扫码登录（自动获取 SESSDATA，AI 字幕用）", "value": "bili-login"},
-                    {"name": "小宇宙登录（官方文稿需 x-jike token）", "value": "xyz-login"},
+                    {"name": "小宇宙扫码登录（官方文稿用，App 扫一扫）", "value": "xyz-login"},
                     {"name": "平台 Cookie（手动填，B 站等需登录内容）", "value": "cookie"},
                     {"name": f"默认笔记位置（图片模式）：{notes_dir}", "value": "notes"},
                     {"name": f"视频理解默认（{'开' if vu_on else '关'} / {vu_int}s，需多模态模型）", "value": "video"},
@@ -1449,7 +1449,7 @@ def _cookie_cli(argv) -> None:
     - `from-browser`：直接读 Safari/Chrome 的登录态（yt-dlp cookiesfrombrowser），最省事
     - `set`：手动粘贴浏览器复制出来的完整 Cookie 字符串
     B 站推荐 `videonote login bilibili` 扫码登录（AI 字幕需要 SESSDATA）。
-    小宇宙官方文稿需要 `x-jike-access-token`（推荐 `videonote login xiaoyuzhou`）。
+    小宇宙官方文稿需要登录态（推荐 `videonote login xiaoyuzhou` 扫码）。
     """
     parser = argparse.ArgumentParser(
         prog="videonote cookie",
@@ -1598,19 +1598,66 @@ def _login_youtube(args, exit_on_fail: bool = True) -> None:
         print(f"{_YELLOW}⚠ 验证失败: {err}（配置已保存，下载时若仍失败可重试）{_RESET}", file=sys.stdout)
 
 
-def _login_xiaoyuzhou(_args, exit_on_fail: bool = True) -> None:
-    """`videonote login xiaoyuzhou`：粘贴小宇宙 x-jike token（官方文稿用）。
+_XIAOYUZHOU_WEB_API = "https://web-api.xiaoyuzhoufm.com"
+_XIAOYUZHOU_QR_CLIENT_ID = "xyz-web"
+_XIAOYUZHOU_MIDWAY_APP_ID = "v6worU4NnWyL"
+_XIAOYUZHOU_QR_POLL_SEC = 2
+_XIAOYUZHOU_QR_MAX_POLLS = 90  # 约 3 分钟
 
-    access token 约 2 小时过期；一并粘贴 refresh token 后过期会自动续期。
-    不把 token 写进 argv（避免进 shell history）；非交互用 `cookie set`。
-    """
+
+def _xiaoyuzhou_web_headers() -> dict:
+    return {
+        "accept": "application/json, text/plain, */*",
+        "content-type": "application/json;charset=UTF-8",
+        "origin": "https://accounts.xiaoyuzhoufm.com",
+        "referer": "https://accounts.xiaoyuzhoufm.com/login",
+        "x-jike-allow-app-token-in-cookie": "true",
+        "x-midway-app-id": _XIAOYUZHOU_MIDWAY_APP_ID,
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+        ),
+    }
+
+
+def _tokens_from_xiaoyuzhou_response(resp, session) -> tuple:
+    """从扫码确认响应取 access/refresh，绝不打印值。"""
+    access = resp.headers.get("x-jike-access-token") or ""
+    refresh = resp.headers.get("x-jike-refresh-token") or ""
+    if session is not None:
+        access = access or (session.cookies.get("x-jike-access-token") or "")
+        refresh = refresh or (session.cookies.get("x-jike-refresh-token") or "")
+    return access, refresh
+
+
+def _print_ascii_qr(data: str) -> None:
+    import qrcode
+
+    qr = qrcode.QRCode(border=1)
+    qr.add_data(data)
+    qr.make(fit=True)
+    try:
+        qr.print_ascii(out=sys.stdout, invert=True)
+    except TypeError:
+        qr.print_ascii(invert=True)
+    print("", file=sys.stdout)
+
+
+def _persist_xiaoyuzhou_tokens(access: str, refresh: str = "") -> str:
+    """保存 token 并实测验证。返回空串=有效，否则是错误信息（不含明文）。"""
     from app.downloaders.xiaoyuzhou_subtitle import (
         format_xiaoyuzhou_cookie,
         verify_xiaoyuzhou_login,
     )
     from app.services.cookie_manager import CookieConfigManager
 
-    _show_header("小宇宙登录")
+    CookieConfigManager().set("xiaoyuzhou", format_xiaoyuzhou_cookie(access, refresh))
+    return verify_xiaoyuzhou_login()
+
+
+def _login_xiaoyuzhou_token(exit_on_fail: bool = True) -> None:
+    """粘贴 x-jike token（扫码不可用时的后备；不把 token 写进 argv）。"""
+    _show_header("小宇宙登录（粘贴 token）")
     print("官方文稿接口需要登录态。请在电脑浏览器登录 https://www.xiaoyuzhoufm.com 后：", file=sys.stdout)
     print("1. 按 F12 → Network → 刷新 → 点任意 api.xiaoyuzhoufm.com 请求", file=sys.stdout)
     print("2. Request Headers 复制 x-jike-access-token（约 2 小时过期）", file=sys.stdout)
@@ -1627,15 +1674,122 @@ def _login_xiaoyuzhou(_args, exit_on_fail: bool = True) -> None:
         print("已取消", file=sys.stdout)
         return
     refresh = inq.secret(message="x-jike-refresh-token（可选，推荐）", keybindings=_KB).execute() or ""
-    CookieConfigManager().set("xiaoyuzhou", format_xiaoyuzhou_cookie(access.strip(), refresh.strip()))
     if not refresh.strip():
         print(f"{_YELLOW}⚠ 未提供 refresh token：access token 约 2 小时后失效，需重新登录{_RESET}", file=sys.stdout)
     print("已保存，正在实测验证（需要网络）…", file=sys.stdout)
-    err = verify_xiaoyuzhou_login()
+    err = _persist_xiaoyuzhou_tokens(access.strip(), refresh.strip())
     if not err:
         print(f"{_GREEN}✓ 小宇宙登录态有效{_RESET}", file=sys.stdout)
         return
     print(f"{_YELLOW}⚠ 验证失败: {err}（配置已保存，生成笔记时若仍失败可重试）{_RESET}", file=sys.stdout)
+
+
+def _login_xiaoyuzhou_qr(exit_on_fail: bool = True) -> None:
+    """官网统一登录扫码：create → 终端 ASCII 二维码 → 轮询 login。"""
+    import time
+
+    import requests
+
+    try:
+        import qrcode  # noqa: F401
+    except ImportError:
+        print("需要 qrcode 库：`uv sync` 后重试", file=sys.stderr)
+        if exit_on_fail:
+            sys.exit(1)
+        return
+
+    session = requests.Session()
+    session.headers.update(_xiaoyuzhou_web_headers())
+    try:
+        created = session.post(
+            f"{_XIAOYUZHOU_WEB_API}/v1/auth/qrcode/create",
+            json={"clientId": _XIAOYUZHOU_QR_CLIENT_ID},
+            timeout=10,
+        )
+        payload = created.json()
+        qr_id = payload.get("id")
+        qr_url = payload.get("url")
+        if created.status_code != 200 or not qr_id or not qr_url:
+            print(f"生成二维码失败: {payload.get('toast') or payload.get('message') or created.status_code}", file=sys.stderr)
+            if exit_on_fail:
+                sys.exit(1)
+            return
+    except Exception as e:
+        print(f"生成二维码失败（网络？）: {e}", file=sys.stderr)
+        if exit_on_fail:
+            sys.exit(1)
+        return
+
+    _show_header("小宇宙扫码登录")
+    print(f"{_YELLOW}请用小宇宙 App「扫一扫」扫描下方二维码（约 3 分钟内有效）{_RESET}", file=sys.stdout)
+    print("扫不了可改用 `videonote login xiaoyuzhou --token` 粘贴 token", file=sys.stdout)
+    _print_ascii_qr(qr_url)
+
+    last_status = None
+    try:
+        for _ in range(_XIAOYUZHOU_QR_MAX_POLLS):
+            time.sleep(_XIAOYUZHOU_QR_POLL_SEC)
+            try:
+                poll = session.post(
+                    f"{_XIAOYUZHOU_WEB_API}/v1/auth/qrcode/login",
+                    json={"id": qr_id},
+                    timeout=10,
+                )
+            except Exception as e:
+                print(f"轮询失败（网络？）: {e}", file=sys.stderr)
+                continue
+            try:
+                data = poll.json() if poll.content else {}
+            except Exception:
+                data = {}
+            if poll.status_code == 401 and data.get("code") == 21:
+                print(f"{_YELLOW}二维码已过期，请重新运行 `videonote login xiaoyuzhou`{_RESET}", file=sys.stdout)
+                return
+            status = data.get("status")
+            if status in ("CONFIRMED", "USED"):
+                access, refresh = _tokens_from_xiaoyuzhou_response(poll, session)
+                if not access:
+                    print("登录成功但未取到 token，请改用 `videonote login xiaoyuzhou --token`", file=sys.stderr)
+                    if exit_on_fail:
+                        sys.exit(1)
+                    return
+                err = _persist_xiaoyuzhou_tokens(access, refresh)
+                print(f"{_GREEN}✓ 已保存小宇宙登录态 —— 官方文稿可直接用了{_RESET}", file=sys.stdout)
+                if err:
+                    print(f"{_YELLOW}⚠ 验证失败: {err}（配置已保存，生成笔记时若仍失败可重试）{_RESET}", file=sys.stdout)
+                try:
+                    input("（按回车返回）")
+                except (EOFError, KeyboardInterrupt):
+                    pass
+                return
+            if status == "SCANNED" and last_status != "SCANNED":
+                print("已扫码，请在手机上确认登录…", file=sys.stdout)
+                last_status = "SCANNED"
+        print(f"{_YELLOW}二维码已过期，请重新运行 `videonote login xiaoyuzhou`{_RESET}", file=sys.stdout)
+    except KeyboardInterrupt:
+        print("（已取消）", file=sys.stdout)
+
+
+def _login_xiaoyuzhou(args, exit_on_fail: bool = True) -> None:
+    """`videonote login xiaoyuzhou`：默认扫码；`--token` 粘贴 x-jike token。
+
+    走官网统一登录（accounts.xiaoyuzhoufm.com）的 create / login 接口。
+    token 不进 argv（避免进 shell history）；非交互用 `cookie set`。
+    """
+    parser = argparse.ArgumentParser(
+        prog="videonote login xiaoyuzhou",
+        description="小宇宙登录（官方文稿用）。默认扫码，--token 改粘贴。",
+    )
+    parser.add_argument(
+        "--token",
+        action="store_true",
+        help="粘贴 x-jike-access-token / refresh-token（不扫码）",
+    )
+    opts = parser.parse_args(args)
+    if opts.token:
+        _login_xiaoyuzhou_token(exit_on_fail)
+        return
+    _login_xiaoyuzhou_qr(exit_on_fail)
 
 
 def _login_cli(argv, exit_on_fail: bool = True) -> None:
@@ -1643,7 +1797,7 @@ def _login_cli(argv, exit_on_fail: bool = True) -> None:
 
     - bilibili：扫码登录，自动获取并保存 SESSDATA（AI 字幕用）
     - youtube：读浏览器登录态或手动粘贴 Cookie（--browser 时实测验证）
-    - xiaoyuzhou：粘贴 x-jike-access-token / refresh-token（官方文稿用）
+    - xiaoyuzhou：扫码登录（`--token` 改粘贴 x-jike token）
 
     exit_on_fail=False 时失败路径只返回不杀进程（setup 向导内调用，#120：
     登录失败不再让整个向导带 traceback/退出，已配的其它设置不丢失）。


### PR DESCRIPTION
## Summary
- `videonote login xiaoyuzhou` 默认走官网统一登录扫码（`web-api.xiaoyuzhoufm.com/v1/auth/qrcode/create` + `/login`），终端 ASCII 二维码，小宇宙 App 确认后保存 token。
- `--token` 保留粘贴后备；凭证不进 MCP、不打印明文。setup 向导同步为扫码。
- 版本保持 **0.1.20**（同版补丁，不升号）。合并后会把 `v0.1.20` 标签挪到本 PR 的 merge commit，并更新 GitHub Release。

## Test plan
- [x] `tests/test_cli.py::TestLoginXiaoyuzhou`（扫码成功 / 过期 / 生成失败 / `--token` 粘贴）
- [x] 全量 805 passed + ruff F/I-clean
- [ ] 合并后本地 `uv run videonote login xiaoyuzhou` 出码，App 扫确认


Made with [Cursor](https://cursor.com)