### PR TITLE
release: v0.1.21（小宇宙扫码登录随版发布）

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/Xiaoyuzhou/local)",
   "author": {
     "name": "HuangYincan",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote"
-version = "0.1.20"
+version = "0.1.21"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/uv.lock
+++ b/uv.lock
@@ -4021,7 +4021,7 @@ wheels = [
 
 [[package]]
 name = "videonote"
-version = "0.1.20"
+version = "0.1.21"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.20"
+__version__ = "0.1.21"


### PR DESCRIPTION
## Summary
- 四处版本对齐到 **0.1.21**：`pyproject.toml` / `videonote_mcp/__init__.py` / `.claude-plugin/plugin.json` / `uv.lock`。
- 把小宇宙扫码登录（#37）正式发到 PyPI。上一版 `videonote==0.1.20` 已占用，无法覆盖；`uvx videonote@latest` 需新号。
- 合并后打 **新标签** `v0.1.21`（不再挪 `v0.1.20`），触发 release.yml → GitHub Release + PyPI。

## Test plan
- [x] 四处版本字符串均为 `0.1.21`
- [ ] CI 绿
- [ ] 合并后打 `v0.1.21` tag，确认 release.yml：四处版本一致 + PyPI 发布
- [ ] 发布后 `uvx videonote@0.1.21 --help` / `uv tool upgrade videonote` 拿到扫码登录


Made with [Cursor](https://cursor.com)