### PR TITLE
release: v0.1.23（小红书扫码 406 修复随版发布）

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/Xiaoyuzhou/Xiaohongshu/local)",
   "author": {
     "name": "HuangYincan",

--- a/VENDOR.md
+++ b/VENDOR.md
@@ -13,7 +13,7 @@
 
 | 子包 | 内容 |
 |------|------|
-| `app/downloaders/` | base, common, bilibili_downloader, bilibili_dm_patch, bilibili_subtitle, **bilibili_comment**, youtube_downloader, youtube_subtitle, douyin_downloader, kuaishou_downloader, local_downloader, **generic_downloader**, **xiaoyuzhou_downloader**, **xiaoyuzhou_subtitle**, **xiaohongshu_downloader**, **xiaohongshu_auth**, **xiaohongshu_sign** + 子包 `douyin_helper/`、`kuaishou_helper/`（旧 stub `xiaoyuzhoufm_download` 已删除 2026-08-17；2026-08-30 重新接入为一等平台 + 官方文稿；2026-08-31 小红书一等平台 + 扫码登录） |
+| `app/downloaders/` | base, common, bilibili_downloader, bilibili_dm_patch, bilibili_subtitle, **bilibili_comment**, youtube_downloader, youtube_subtitle, douyin_downloader, kuaishou_downloader, local_downloader, **generic_downloader**, **xiaoyuzhou_downloader**, **xiaoyuzhou_subtitle**, **xiaohongshu_downloader**, **xiaohongshu_auth**, **xiaohongshu_sign**, **xiaohongshu_browser** + 子包 `douyin_helper/`、`kuaishou_helper/`（旧 stub `xiaoyuzhoufm_download` 已删除 2026-08-17；2026-08-30 重新接入为一等平台 + 官方文稿；2026-08-31 小红书一等平台 + 扫码登录；同日扫码改为本机 Chrome 跑官网 JS，因 edith 拒旧 x-s 406） |
 | `app/transcriber/` | base, transcriber_provider, whisper, groq, bcut, kuaishou, mlx_whisper_transcriber, **funasr_transcriber**, **audio_preprocess**, model_download_state, whisper_models |
 | `app/gpt/` | base, gpt_factory, universal_gpt, prompt, prompt_builder, request_chunker + `app/gpt/provider/OpenAI_compatible_provider.py`（gpt_factory 依赖）（openai_gpt / deepseek_gpt / qwen_gpt / utils / tools **已删除** 2026-08-17：全仓零引用——gpt_factory 走 OpenAICompatibleProvider 直连，上游直连类死代码） |
 | `app/db/` | engine, init_db, provider_dao, model_dao, video_task_dao + `app/db/models/`（models, providers, video_tasks）（sqlite_client **已删除** 2026-08-17：全仓零引用 + CWD 相对 DB 路径死引信） |
@@ -56,7 +56,7 @@
 - `app/transcriber/whisper.py` / `mlx_whisper_transcriber.py` / `app/utils/model_status.py`（2026-08-25 #142 A2：内置模型 revision 固定——whisper 经 `WhisperModel(revision=…)`、mlx 经 `snapshot_download(revision=…)`，映射/散列单一来源在 model_status；上游若带原生下载逻辑需人工合并）
 - `app/downloaders/youtube_downloader.py`（2026-08-25 #142 A4：`VIDEONOTE_YTDLP_EJS` 开关控制 `remote_components`——上游默认无此 env 门禁，同步需人工合并）
 - `app/gpt/universal_gpt.py`（checkpoint 损坏弃用时打 warning 留痕，#106）
-- 整文件为本仓库新增：`pipeline.py`、`merge.py`、`diarization.py`、`inspect.py`、`note_cache.py`、`audio_preprocess.py`、`funasr_transcriber.py`、`generic_downloader.py`、`bilibili_comment.py`、`xiaoyuzhou_downloader.py`、`xiaoyuzhou_subtitle.py`、`xiaohongshu_downloader.py`、`xiaohongshu_auth.py`、`xiaohongshu_sign.py`、`task_manifest.py`、`json_store.py`、`url_safety.py`
+- 整文件为本仓库新增：`pipeline.py`、`merge.py`、`diarization.py`、`inspect.py`、`note_cache.py`、`audio_preprocess.py`、`funasr_transcriber.py`、`generic_downloader.py`、`bilibili_comment.py`、`xiaoyuzhou_downloader.py`、`xiaoyuzhou_subtitle.py`、`xiaohongshu_downloader.py`、`xiaohongshu_auth.py`、`xiaohongshu_sign.py`、`xiaohongshu_browser.py`、`task_manifest.py`、`json_store.py`、`url_safety.py`
 
 ## 如何同步上游更新
 

--- a/app/downloaders/xiaohongshu_auth.py
+++ b/app/downloaders/xiaohongshu_auth.py
@@ -29,7 +29,6 @@ HOME = "https://www.xiaohongshu.com"
 QR_CREATE = "/api/sns/web/v1/login/qrcode/create"
 QR_STATUS = "/api/sns/web/v1/login/qrcode/status"
 ACTIVATE = "/api/sns/web/v1/login/activate"
-USER_ME = "/api/sns/web/v2/user/me"
 ORIGIN_CDN = "https://sns-video-bd.xhscdn.com"
 _LOGIN_HINT = (
     "配置请走 CLI：`! videonote login xiaohongshu` 或 "
@@ -314,6 +313,12 @@ class XiaohongshuAuth:
             msg = ""
             if isinstance(body, dict):
                 msg = body.get("msg") or body.get("message") or ""
+            if resp.status_code == 406:
+                raise RuntimeError(
+                    "小红书拒绝了旧版请求签名（HTTP 406）。"
+                    "请安装 Google Chrome 后重试扫码，或 "
+                    "`videonote login xiaohongshu --cookie`"
+                )
             raise RuntimeError(f"生成二维码失败: {msg or resp.status_code}")
         return {
             "qr_id": data.get("qr_id") or "",
@@ -411,25 +416,20 @@ def verify_xiaohongshu_login(cookie_mgr: Optional[CookieConfigManager] = None) -
     auth = XiaohongshuAuth(cookie_mgr=mgr)
     try:
         auth._apply_cookie_string(format_cookie(cookies))
-        if not auth._a1():
-            auth._seed_device()
-        resp = auth._request("GET", f"{EDITH}{USER_ME}", uri=USER_ME)
-        if resp.status_code == 200:
-            try:
-                body = resp.json()
-            except ValueError:
-                body = {}
-            data = body.get("data") if isinstance(body, dict) else None
-            if isinstance(data, dict) and (data.get("user_id") or data.get("userid") or data.get("nickname")):
-                return ""
-            if isinstance(body, dict) and body.get("success"):
-                return ""
-            # 200 但无用户字段：cookie 在，接口形状变了——视为已保存
-            if resp.status_code == 200:
-                return ""
+        session = auth._session_obj()
+        headers = {
+            "User-Agent": _UA,
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+            "Referer": f"{HOME}/",
+        }
+        # 不用 edith user/me：旧版 x-s 会被 406，误报登录失败。
+        resp = session.get(HOME, headers=headers, timeout=15, proxies=_proxies())
         if resp.status_code in (401, 403, 471):
             return "登录态无效或已过期，请重新 `videonote login xiaohongshu`"
-        return f"HTTP {resp.status_code}"
+        if resp.status_code != 200:
+            return f"HTTP {resp.status_code}"
+        return ""
     except Exception as exc:  # noqa: BLE001
         logger.info("小红书登录探测失败: %s", exc)
         return "请求失败（网络？检查 `videonote proxy list`）"

--- a/app/downloaders/xiaohongshu_browser.py
+++ b/app/downloaders/xiaohongshu_browser.py
@@ -1,0 +1,228 @@
+"""小红书扫码：用本机 Chrome 打开官网，让官方 JS 签名出码。
+
+edith `qrcode/create` 已拒绝旧版 x-s（HTTP 406）。登录页在真实 Chrome 里
+会自己带现行签名；我们拦截 create 的 JSON 拿二维码 URL，终端仍出 ASCII 码，
+轮询期间保持页面存活（站点自己打 userinfo）。
+"""
+from __future__ import annotations
+
+from typing import Optional
+from urllib.parse import parse_qs, urlparse
+
+from app.downloaders.xiaohongshu_auth import HOME, QR_SUCCESS, QR_WAIT, format_cookie
+from app.services.cookie_manager import CookieConfigManager
+from app.services.proxy_config_manager import ProxyConfigManager
+from app.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_CREATE_MARK = "/login/qrcode/create"
+_USERINFO_MARK = "/api/qrcode/userinfo"
+_STATUS_MARK = "/login/qrcode/status"
+_EXPLORE = f"{HOME}/explore"
+_LAUNCH_TRIES = (
+    {"channel": "chrome", "headless": True},
+    {"channel": "msedge", "headless": True},
+    {"headless": True},
+)
+
+
+class BrowserQrUnavailable(RuntimeError):
+    """本机没有可用的 Playwright / Chrome。"""
+
+
+def parse_qr_create_payload(body: dict) -> dict:
+    """从 qrcode/create JSON 抽出 {url, qr_id, code}。字段名兼容驼峰/下划线。"""
+    data = body.get("data") if isinstance(body, dict) else None
+    if not isinstance(data, dict):
+        data = {}
+    url = str(data.get("url") or "")
+    qr_id = str(data.get("qr_id") or data.get("qrId") or "")
+    code = str(data.get("code") or data.get("xhs_code") or data.get("xhsCode") or "")
+    if url and (not qr_id or not code):
+        qs = parse_qs(urlparse(url).query)
+        qr_id = qr_id or (qs.get("qrId") or qs.get("qr_id") or [""])[0]
+        code = code or (qs.get("xhs_code") or qs.get("code") or [""])[0]
+    return {"url": url, "qr_id": qr_id, "code": code}
+
+
+def poll_status_from_payload(body: dict) -> Optional[int]:
+    """userinfo / qrcode/status → 0 等待 / 1 已扫 / 2 成功 / 3 过期。"""
+    if not isinstance(body, dict):
+        return None
+    data = body.get("data") if isinstance(body.get("data"), dict) else body
+    for key in ("codeStatus", "code_status", "status"):
+        if data.get(key) is None:
+            continue
+        try:
+            return int(data.get(key))
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def cookies_from_playwright(raw_cookies: list) -> dict:
+    """只留 xiaohongshu.com 域；同名后者覆盖。"""
+    out = {}
+    for item in raw_cookies or []:
+        if not isinstance(item, dict):
+            continue
+        domain = (item.get("domain") or "").lower()
+        if "xiaohongshu.com" not in domain:
+            continue
+        name = item.get("name")
+        if name:
+            out[name] = item.get("value") or ""
+    return out
+
+
+class XiaohongshuBrowserQr:
+    """与 XiaohongshuAuth 同款：create_qr / poll_qr / persist / close。"""
+
+    pumps_events = True
+
+    def __init__(self, cookie_mgr: Optional[CookieConfigManager] = None):
+        self._cookie_mgr = cookie_mgr or CookieConfigManager()
+        self._pw = None
+        self._browser = None
+        self._context = None
+        self._page = None
+        self._created: dict = {}
+        self._status = QR_WAIT
+        self._guest_session = ""
+        self._logged_cookies: dict = {}
+
+    def _on_response(self, resp) -> None:
+        url = resp.url or ""
+        try:
+            body = resp.json()
+        except Exception:  # noqa: BLE001
+            return
+        if not isinstance(body, dict):
+            return
+        if _CREATE_MARK in url:
+            parsed = parse_qr_create_payload(body)
+            if parsed.get("url"):
+                self._created = parsed
+            return
+        if _USERINFO_MARK in url or _STATUS_MARK in url:
+            st = poll_status_from_payload(body)
+            if st is not None:
+                self._status = st
+
+    def _launch(self) -> None:
+        try:
+            from playwright.sync_api import sync_playwright
+        except ImportError as exc:
+            raise BrowserQrUnavailable(
+                "缺少 playwright。请 `uv sync` 或 `uvx --with playwright videonote login xiaohongshu`"
+            ) from exc
+        proxy = ProxyConfigManager().get_proxy_url()
+        launch_proxy = {"server": proxy} if proxy else None
+        self._pw = sync_playwright().start()
+        last_err: Optional[Exception] = None
+        for kwargs in _LAUNCH_TRIES:
+            try:
+                opts = dict(kwargs)
+                if launch_proxy:
+                    opts["proxy"] = launch_proxy
+                self._browser = self._pw.chromium.launch(**opts)
+                logger.info("小红书扫码浏览器: %s", kwargs)
+                break
+            except Exception as exc:  # noqa: BLE001
+                last_err = exc
+                logger.info("启动浏览器失败 %s: %s", kwargs, exc)
+        if self._browser is None:
+            raise BrowserQrUnavailable(
+                f"无法启动 Chrome/Edge（{last_err}）。请安装 Google Chrome，或改用 "
+                "`videonote login xiaohongshu --cookie`"
+            )
+        self._context = self._browser.new_context(
+            locale="zh-CN",
+            viewport={"width": 1280, "height": 800},
+            user_agent=(
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"
+            ),
+        )
+        self._page = self._context.new_page()
+        self._page.on("response", self._on_response)
+
+    def _cookies(self) -> dict:
+        if self._context is None:
+            return {}
+        try:
+            return cookies_from_playwright(self._context.cookies())
+        except Exception:  # noqa: BLE001
+            return {}
+
+    def create_qr(self) -> dict:
+        self._launch()
+        assert self._page is not None
+        try:
+            self._page.goto(_EXPLORE, wait_until="domcontentloaded", timeout=45000)
+        except Exception as exc:
+            raise RuntimeError(f"打开小红书失败: {exc}") from exc
+        self._page.wait_for_timeout(1500)
+        self._guest_session = self._cookies().get("web_session") or ""
+        clicked = False
+        for sel in ("text=登录", "button:has-text('登录')"):
+            loc = self._page.locator(sel).first
+            try:
+                if loc.count() and loc.is_visible():
+                    loc.click(timeout=5000)
+                    clicked = True
+                    break
+            except Exception:  # noqa: BLE001
+                continue
+        if not clicked:
+            logger.info("未点到登录按钮，等待页面自带二维码")
+        for _ in range(40):
+            if self._created.get("url"):
+                break
+            self._page.wait_for_timeout(500)
+        if not self._created.get("url"):
+            raise RuntimeError(
+                "未拿到小红书二维码（登录框没出来？）。改用 "
+                "`videonote login xiaohongshu --cookie`"
+            )
+        return dict(self._created)
+
+    def poll_qr(self, qr_id: str, code: str) -> dict:
+        """抽一次站点轮询结果；内部 wait 以便 Playwright 收包。"""
+        if self._page is not None:
+            try:
+                self._page.wait_for_timeout(2000)
+            except Exception:  # noqa: BLE001
+                pass
+        cookies = self._cookies()
+        sess = cookies.get("web_session") or ""
+        if self._guest_session and sess and sess != self._guest_session:
+            self._status = QR_SUCCESS
+            self._logged_cookies = cookies
+        elif self._status == QR_SUCCESS and cookies:
+            self._logged_cookies = cookies
+        return {"code_status": self._status, "login_info": {}}
+
+    def persist(self) -> str:
+        cookies = self._logged_cookies or self._cookies()
+        if not cookies.get("web_session"):
+            return "登录成功但未取到 web_session"
+        self._cookie_mgr.set("xiaohongshu", format_cookie(cookies))
+        return ""
+
+    def close(self) -> None:
+        for obj in (self._page, self._context, self._browser):
+            if obj is None:
+                continue
+            try:
+                obj.close()
+            except Exception:  # noqa: BLE001
+                pass
+        self._page = self._context = self._browser = None
+        if self._pw is not None:
+            try:
+                self._pw.stop()
+            except Exception:  # noqa: BLE001
+                pass
+            self._pw = None

--- a/commands/videonote-setup.md
+++ b/commands/videonote-setup.md
@@ -56,7 +56,7 @@ description: 配置 VideoNote-MCP：体检 / LLM 供应商 / 转写引擎 / 默�
 
 - **B 站**（AI 字幕 / 评论）：`! videonote login bilibili`。没配 SESSDATA 时仍可转写（走语音识别），只是拿不到 AI 字幕 / 弹幕评论。
 - **小宇宙**（官方文稿）：`! videonote login xiaoyuzhou`。未登录会回退本地下载 + ASR，长节目会很慢。
-- **小红书**（视频笔记）：`! videonote login xiaohongshu`。公开视频有时无需登录；遇登录墙 / 验证码时需要。图文笔记无法转写。扫不了可用 `--cookie` 粘贴。
+- **小红书**（视频笔记）：`! videonote login xiaohongshu`（本机需 Chrome/Edge）。公开视频有时无需登录；遇登录墙 / 验证码时需要。图文笔记无法转写。扫不了可用 `--cookie` 粘贴。
 
 ## 6. 数据管理（可选）
 

--- a/docs/00-新手上路.md
+++ b/docs/00-新手上路.md
@@ -51,7 +51,7 @@ URL / file:// / 本地路径
 ### 验证三件套（每次改动后跑）
 
 ```bash
-uv run pytest -q            # 全量 841 测试（当前基线）
+uv run pytest -q            # 全量 847 测试（当前基线）
 uv run ruff check --select F .   # F 类（语法/未定义）——CI 门槛
 uv run ruff check --select I .   # import 排序——CI 门槛
 ```
@@ -108,7 +108,7 @@ docs: 回填 #N commit hash（<hash>）
 
 ## 六、当前状态（2026-08-22 基线）
 
-- **10 工具**（精确名单在 `ci.yml`；#135/#136 精简自 39，再 #138 16→10）、**841 tests**、ruff F/I-clean。
+- **10 工具**（精确名单在 `ci.yml`；#135/#136 精简自 39，再 #138 16→10）、**847 tests**、ruff F/I-clean。
 - 最近一轮：`docs/05` **#142 安全扫描收尾**（MCP 本地文件/危险操作边界开关 + 模型 revision 固定 + B站弹幕 XML 安全解析 + YouTube EJS 开关 + MD5 FIPS 兼容；详见 05）。上一轮 #141（#140 安全复扫）。
 - **死代码纪律**：先跑 AST import 图 + 名字引用计数双扫描再动手；`from X import Y` 的 Y 是字符串不是 Name 节点（v1 扫描漏检过）；删函数后 grep 全仓（含 tests/CLI）确认零引用，VENDOR.md 同步，留意 dangling 装饰器/finally。
 - **未实施的开放候选**（#133 登记「建议后续」，见 `05` 尾部）：A2 固定 tmp+0644 写盘收尾、B4 diarize normalize 残留 wav、B5 local/kuaishou 转码不响应取消、B6 Provider DAO 吞异常、C5 全局 /tmp 断言、C6 conftest setdefault 不对称、C7 Dockerfile 缺 skills、C8 测试硬编码 /tmp、C9 单文件直跑、C10 CLI download choices 缺档；#132 C 组 6 项（C3/C5/C6/C7/C11/C12）。

--- a/docs/04-使用手册.md
+++ b/docs/04-使用手册.md
@@ -96,7 +96,7 @@ videonote login bilibili     # 扫码登录，二维码渲染进终端/会话，
 # 小宇宙：优先用官方文稿跳过本地 ASR（47 分钟单集否则会转写很久）
 videonote login xiaoyuzhou   # 扫码登录（小宇宙 App）；`--token` 改粘贴
 # 小红书：原生下载器；登录墙/验证码时需要登录态
-videonote login xiaohongshu  # 扫码登录（小红书 App）；`--cookie` 改粘贴
+videonote login xiaohongshu  # 扫码（本机需 Chrome/Edge）；`--cookie` 改粘贴
 videonote transcriber set groq                        # 切云端
 ```
 
@@ -126,7 +126,7 @@ get_config()                         # transcriber 段：当前引擎/尺寸/就
 # Cookie / token 不进 MCP 工具参数（会进对话上游）——一律走本会话终端：
 ! videonote login bilibili        # 扫码登录，自动保存 SESSDATA
 ! videonote login xiaoyuzhou      # 扫码登录（小宇宙 App）；`--token` 改粘贴
-! videonote login xiaohongshu     # 扫码登录（小红书 App）；`--cookie` 改粘贴
+! videonote login xiaohongshu     # 扫码（本机 Chrome/Edge）；`--cookie` 改粘贴
 # 或 setup 向导的 Cookie / 登录步骤
 # 非交互：videonote cookie set xiaoyuzhou 'x-jike-access-token=...; x-jike-refresh-token=...'
 # 非交互：videonote cookie set xiaohongshu 'web_session=...; a1=...'
@@ -134,7 +134,7 @@ get_config()                         # transcriber 段：当前引擎/尺寸/就
 
 小宇宙官方文稿接口 `POST /v1/episode-transcript/get` 需要登录态。access token 约 2 小时过期；配了 refresh token 后过期会自动续期。未登录时该期会回退本地下载音频 + ASR（长节目会非常慢）。
 
-小红书走原生笔记页解析（`__INITIAL_STATE__` 视频直链），图文笔记会明确报错。公开视频有时无需登录；遇到登录墙 / 验证码时先 `! videonote login xiaohongshu`。无官方字幕，转写走本地/云端引擎。
+小红书走原生笔记页解析（`__INITIAL_STATE__` 视频直链），图文笔记会明确报错。公开视频有时无需登录；遇到登录墙 / 验证码时先 `! videonote login xiaohongshu`（本机需已装 Chrome 或 Edge；扫码走官网登录页，终端出 ASCII 码）。无官方字幕，转写走本地/云端引擎。
 
 ## 环境变量（可选）
 
@@ -387,7 +387,8 @@ claude plugin install videonote@videonote
 | 首次转写卡在 `INITIALIZING` | 正在下载 whisper 模型，耐心等；模型大可改用云端转写 |
 | `inspect_video` 返回 `platform:"generic"` | 内置平台之外自动走 yt-dlp 通用提取（覆盖 1800+ 站点）；仍失败（登录墙/JS）才需 Agent 接手 |
 | 小宇宙走了很久本地转写 | 未配登录态，官方文稿拿不到。让用户 `! videonote login xiaoyuzhou` 后重试（有文稿则跳过 ASR） |
-| 小红书下载失败 / 图文笔记 | 图文笔记无法转写。视频笔记遇登录墙让用户 `! videonote login xiaohongshu` 后重试。`inspect_video` 应返回 `platform:"xiaohongshu"` |
+| 小红书下载失败 / 图文笔记 | 图文笔记无法转写。视频笔记遇登录墙让用户 `! videonote login xiaohongshu` 后重试（需本机 Chrome/Edge；没有就 `--cookie`）。`inspect_video` 应返回 `platform:"xiaohongshu"` |
+| 小红书扫码报 HTTP 406 | 旧版直连接口已被拒。升级后扫码改走本机 Chrome 打开官网。请安装 Google Chrome 后重试，或 `--cookie` 粘贴 |
 | `process_media`（diarize）报需安装/缺 token | pyannote 可选重依赖：`transcriber diarization on` 引导安装 + 配 HF_TOKEN + 同意模型授权 |
 | 任务长时间卡住 | `task` 看 message；可能视频很长或模型下载中，耐心等待或换小模型 |
 | 中文乱码/内容差 | 检查所选模型能力；`style` 会影响输出格式 |

--- a/docs/06-执行进度.md
+++ b/docs/06-执行进度.md
@@ -356,3 +356,4 @@
 ## 小红书原生支持（2026-08-31）
 
 - [x] 小红书升为一等平台：`detect_platform` 识别 `xiaohongshu.com` / `xhslink.com` / `rednote.com`；笔记页 `__INITIAL_STATE__` 取视频直链；图文笔记明确拒绝。CLI `login xiaohongshu` 默认扫码（`--cookie` 粘贴），凭证不进 MCP。**841 passed + ruff F/I-clean**。
+- [x] 扫码 406 修复：edith 拒旧 x-s，改本机 Chrome 打开官网出码（Playwright `channel=chrome`）；`--cookie` 仍可用。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -796,3 +796,9 @@ v0.1.1 → v0.1.2 的主要变更（详见下方各「维护」节点块；稳�
 - **登录**：`videonote login xiaohongshu` 默认扫码（edith `qrcode/create` + `qrcode/status`）；`--cookie` 粘贴浏览器 Cookie。凭证走 CLI，不进 MCP。
 - **inspect / 转写缓存**：`inspect_video` 原生解析单条笔记；`note_cache` 按笔记 id 命中。
 - Skill / 04 / VENDOR 同步；改 Skill 后需刷新插件。
+
+## 小红书扫码改走官网 Chrome（2026-08-31 · 修复 login 406）
+
+- **原因**：edith `qrcode/create` 拒绝旧版 x-s，HTTP 406 `{"code":-1,"success":false}`。
+- **修复**：`videonote login xiaohongshu` 用本机 Chrome/Edge 打开官网登录页（Playwright），拦截官方签名后的 create 响应，终端仍出 ASCII 码；无浏览器时回退直连接口并提示 `--cookie`。
+- 登录探测改为 GET 首页，不再打会 406 的 edith `user/me`。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote"
-version = "0.1.22"
+version = "0.1.23"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,10 @@ dependencies = [
     "gmssl>=3.2.2",
     # 交互式 setup 向导（方向键选择/高亮；无则回退纯文本提示）
     "InquirerPy>=0.3.4",
-    # B 站扫码登录（终端 ASCII 二维码）
+    # B 站 / 小红书扫码登录（终端 ASCII 二维码）
     "qrcode>=8.0",
+    # 小红书扫码：edith 已拒旧版 x-s（406），需本机 Chrome 跑官网 JS 出码
+    "playwright>=1.48.0",
 ]
 
 [project.optional-dependencies]

--- a/skills/videonote/reference/troubleshooting.md
+++ b/skills/videonote/reference/troubleshooting.md
@@ -15,7 +15,8 @@
 | B 站下载报 `fatal` / playurl 412 | 已修复（yt-dlp fatal 透传）；仍失败则让用户 `videonote login bilibili`（扫码存 SESSDATA）后重试 |
 | 想用 B 站 **AI 字幕**跳过语音识别 | 引导用户跑 `videonote login bilibili`（扫码自动存 SESSDATA）。AI 字幕需登录态；`raw_info.subtitles={}` 只反映手动 CC，AI 字幕在 automatic_captions |
 | 小宇宙长时间卡在转写 / 想用官方文稿 | 未配登录态会走本地下载+ASR。引导用户 `! videonote login xiaoyuzhou`（终端扫码，小宇宙 App 确认）后重试；扫不了再用 `--token`。`inspect_video` 应返回 `platform:"xiaoyuzhou"` |
-| 小红书下载失败 / 图文笔记 | 图文笔记无法转写。视频遇登录墙/验证码：引导用户 `! videonote login xiaohongshu`（终端扫码）；扫不了再用 `--cookie`。`inspect_video` 应返回 `platform:"xiaohongshu"` |
+| 小红书下载失败 / 图文笔记 | 图文笔记无法转写。视频遇登录墙/验证码：引导用户 `! videonote login xiaohongshu`（终端扫码，需本机 Chrome/Edge）；扫不了再用 `--cookie`。`inspect_video` 应返回 `platform:"xiaohongshu"` |
+| 小红书扫码报 406 | 旧版直连接口签名已失效。请用户升级 videonote 后重试扫码（走本机 Chrome）；或 `! videonote login xiaohongshu --cookie` |
 | 整合评论/弹幕时评论拿不到 | 未配 B 站 SESSDATA —— 引导用户 `videonote login bilibili`；抓取失败**不阻断**笔记生成（跳过该部分） |
 | 其他平台（非内置平台） | `inspect_video` 返回 `platform:"generic"` → 自动走 **yt-dlp 通用提取**（覆盖 1800+ 站点）；若也失败任务报错 → Agent 接手：WebFetch/浏览器解析视频源后 `generate_note(video_url="/绝对/路径/x.mp4", platform="local")` |
 | generic 下载报需登录/JS 渲染 | 该站点 yt-dlp 无法直接提取 —— Agent 用 WebFetch/浏览器处理登录/验证，或让用户 `videonote setup` 向导里配「平台 Cookie」后重试 |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -533,7 +533,7 @@ class TestLoginXiaohongshu:
             def close(self):
                 pass
 
-        monkeypatch.setattr("app.downloaders.xiaohongshu_auth.XiaohongshuAuth", _Auth)
+        monkeypatch.setattr(cli, "_open_xiaohongshu_qr_session", lambda: _Auth())
         monkeypatch.setattr(time, "sleep", lambda *_: None)
         monkeypatch.setattr(cli, "_print_ascii_qr", lambda data: print(f"QR:{data}", file=sys.stdout))
         monkeypatch.setattr("builtins.input", lambda *_: "")
@@ -560,7 +560,7 @@ class TestLoginXiaohongshu:
             def close(self):
                 pass
 
-        monkeypatch.setattr("app.downloaders.xiaohongshu_auth.XiaohongshuAuth", _Auth)
+        monkeypatch.setattr(cli, "_open_xiaohongshu_qr_session", lambda: _Auth())
         monkeypatch.setattr(time, "sleep", lambda *_: None)
         monkeypatch.setattr(cli, "_print_ascii_qr", lambda data: None)
         monkeypatch.setattr("builtins.input", lambda *_: "")
@@ -572,7 +572,7 @@ class TestLoginXiaohongshu:
             def create_qr(self):
                 raise RuntimeError("sign error")
 
-        monkeypatch.setattr("app.downloaders.xiaohongshu_auth.XiaohongshuAuth", _Auth)
+        monkeypatch.setattr(cli, "_open_xiaohongshu_qr_session", lambda: _Auth())
         with pytest.raises(SystemExit) as ei:
             cli._login_xiaohongshu([])
         assert ei.value.code == 1

--- a/tests/test_xiaohongshu.py
+++ b/tests/test_xiaohongshu.py
@@ -293,6 +293,76 @@ class QrLoginTest(unittest.TestCase):
             auth.create_qr()
         self.assertIn("生成二维码失败", str(ei.exception))
 
+    def test_create_406_mentions_cookie(self):
+        def handler(method, url, **kwargs):
+            return _FakeResp(status=406, payload={"code": -1, "success": False})
+
+        auth = XiaohongshuAuth(session=_FakeSession(handler), cookie_mgr=mock.Mock())
+        with self.assertRaises(RuntimeError) as ei:
+            auth.create_qr()
+        msg = str(ei.exception)
+        self.assertIn("406", msg)
+        self.assertIn("--cookie", msg)
+
+
+class BrowserQrParseTest(unittest.TestCase):
+    def test_parse_create_underscores(self):
+        from app.downloaders.xiaohongshu_browser import parse_qr_create_payload
+
+        out = parse_qr_create_payload({
+            "data": {"url": "xhsdiscover://login", "qr_id": "qid", "code": "c1"},
+        })
+        self.assertEqual(out["url"], "xhsdiscover://login")
+        self.assertEqual(out["qr_id"], "qid")
+        self.assertEqual(out["code"], "c1")
+
+    def test_parse_create_from_query(self):
+        from app.downloaders.xiaohongshu_browser import parse_qr_create_payload
+
+        url = (
+            "https://www.xiaohongshu.com/mobile/login"
+            "?qrId=60231788145547560&xhs_code=991693&channel_type=web"
+        )
+        out = parse_qr_create_payload({"data": {"url": url}})
+        self.assertEqual(out["qr_id"], "60231788145547560")
+        self.assertEqual(out["code"], "991693")
+        self.assertTrue(out["url"].startswith("https://"))
+
+    def test_poll_status_camel_and_snake(self):
+        from app.downloaders.xiaohongshu_browser import poll_status_from_payload
+
+        self.assertEqual(poll_status_from_payload({"data": {"codeStatus": 1}}), 1)
+        self.assertEqual(poll_status_from_payload({"data": {"code_status": 2}}), 2)
+        self.assertIsNone(poll_status_from_payload({"data": {}}))
+
+    def test_cookies_filter_domain(self):
+        from app.downloaders.xiaohongshu_browser import cookies_from_playwright
+
+        raw = [
+            {"name": "web_session", "value": "s1", "domain": ".xiaohongshu.com"},
+            {"name": "other", "value": "nope", "domain": ".example.com"},
+            {"name": "a1", "value": "aaa", "domain": "edith.xiaohongshu.com"},
+        ]
+        out = cookies_from_playwright(raw)
+        self.assertEqual(out["web_session"], "s1")
+        self.assertEqual(out["a1"], "aaa")
+        self.assertNotIn("other", out)
+
+    def test_poll_detects_session_change(self):
+        from app.downloaders.xiaohongshu_browser import XiaohongshuBrowserQr
+
+        qr = XiaohongshuBrowserQr(cookie_mgr=mock.Mock())
+        qr._guest_session = "guest-sess"
+        qr._page = None
+        qr._cookies = lambda: {"web_session": "logged-sess", "a1": "aaa"}
+        poll = qr.poll_qr("qid", "c")
+        self.assertEqual(poll["code_status"], QR_SUCCESS)
+        self.assertEqual(qr.persist(), "")
+        qr._cookie_mgr.set.assert_called_once()
+        saved = qr._cookie_mgr.set.call_args.args[1]
+        self.assertIn("web_session=logged-sess", saved)
+        self.assertNotIn("guest-sess", saved)
+
 
 class VerifyLoginTest(unittest.TestCase):
     def test_missing_session(self):

--- a/uv.lock
+++ b/uv.lock
@@ -916,7 +916,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/61/16/71eefcf68267bbf06a9b6bff57d0b222e49432326e85d74348b67694b8d4/greenlet-3.5.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e883de250e299654b1f1680f72a1a9f9ba62c9bd1bce84099c90657349a8dfbb", size = 294266, upload-time = "2026-07-22T11:37:56.142Z" },
     { url = "https://files.pythonhosted.org/packages/36/ea/a0b19adfc35d07e10acb626e9d22a3893b95f1309c42c4a20161dec16800/greenlet-3.5.4-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32802705c2c1ff25e8237b3bdacf2594fa02be80af8a66703eb7853ea7e68686", size = 613712, upload-time = "2026-07-22T12:26:39.375Z" },
     { url = "https://files.pythonhosted.org/packages/54/76/a121978b3337407d05a1ce5f79b4aa5998a43a9d8422f9726029b90b4471/greenlet-3.5.4-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57aa201b351f7c7c75627c60d29e4d5b97a07d37efeb62b903466fca42c097d7", size = 625582, upload-time = "2026-07-22T12:29:00.814Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4a/f301f1d85c69a86b90b5d581a73e8927bba4e79450037e6e2cbca05eb4fd/greenlet-3.5.4-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9667862a2e38ad379f11b845daeda22c8989186def44f06962c9c4c05e556da7", size = 633429, upload-time = "2026-07-22T12:43:42.073Z" },
     { url = "https://files.pythonhosted.org/packages/34/c2/080f16cf870e929e592f55767f01d6c98d2ee83bfdc36c3b892f2d0459ab/greenlet-3.5.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c3fe76c2cac86b4f7a1e92865ac0a54384deb05c92986287c1a7110d9bd53071", size = 624663, upload-time = "2026-07-22T11:51:08.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2e/26884072b0eb343a4d5fee903341bfe5171b32b7f14553886e2b6349135a/greenlet-3.5.4-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:ae53534b5dec0f4c2ec26f898f538dc8ea1ca3ef2927d597a9439e40a09da937", size = 428238, upload-time = "2026-07-22T12:39:49.973Z" },
     { url = "https://files.pythonhosted.org/packages/9e/bb/8f3ca88370b817369008faeceeee85970adc16c92a70a3e5fe5fea495a57/greenlet-3.5.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1e1a4a684b16c45ba324e60b32a4386a87722bcb815d2a149d2182f9b401ca72", size = 1585010, upload-time = "2026-07-22T12:25:02.539Z" },
     { url = "https://files.pythonhosted.org/packages/51/c2/45877154689709ebce9a0b83c2235e6ca0f31577889b02af308c8cc5f8fb/greenlet-3.5.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e849e6e139b9671adeac505f72fc05f4af7fd1921faef40295e214fc3b361b59", size = 1651283, upload-time = "2026-07-22T11:51:10.408Z" },
     { url = "https://files.pythonhosted.org/packages/cd/7d/8711a75cb61d85246277c07ff6e1a6504621ba473d808c11ad225ffca43f/greenlet-3.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:dc418cf4c873357964d6624445ed09472e50def990c65dd4e76fc3ba8cd9cef6", size = 246434, upload-time = "2026-07-22T11:43:15.557Z" },
@@ -924,7 +926,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/04/81bd731d6d1e3a469d9a4c36f5eb069bcf0cbb2d5d342c9fec22245b91fc/greenlet-3.5.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3d66250e8b09f182ede05490998c818b5961f7a3640332d44c4927caec7bbfe4", size = 295909, upload-time = "2026-07-22T11:38:09.261Z" },
     { url = "https://files.pythonhosted.org/packages/cc/dd/f5f22903a6ae70f5ea328ed0beaec92ad903f0e3b7d2845133b354abc4b8/greenlet-3.5.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c90e930c9c192e5b3ee9fb8bcd920ea3926155e2e3ded39fc697323addecee17", size = 612011, upload-time = "2026-07-22T12:26:40.69Z" },
     { url = "https://files.pythonhosted.org/packages/8e/10/92a4a88d12b915d74ea5b6d288e4afefda4771647caa34442c156f7a454f/greenlet-3.5.4-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:791fdfeeb9c6e0c7b10fa151bf110d2a6974866f13dcb5b1c7efae698245893a", size = 624299, upload-time = "2026-07-22T12:29:02.089Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/f9/03e26be3487c5238e81f2b84714959a86ea8515a869828cf41f4fc54b34e/greenlet-3.5.4-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b7c895310363f310361e0fe2072af85269d2a2a285cd04c0c59e79a5e3670dcf", size = 629603, upload-time = "2026-07-22T12:43:43.456Z" },
     { url = "https://files.pythonhosted.org/packages/50/6d/0b14bb9db2989f32cd9fe7f76afedea01ee8bee3f87c07e69f24adfe7e63/greenlet-3.5.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f88193799d43dbf8c8a806d6405c9c52fe2af40bf75072a606357b33cc336c7f", size = 621541, upload-time = "2026-07-22T11:51:09.464Z" },
+    { url = "https://files.pythonhosted.org/packages/57/6b/7c55ca72ef80d57c16c4a55210f82582622462dc4485799a30f4ec6f3372/greenlet-3.5.4-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:13b980043cb1b3134e81ea469da1250ddcc6bfe6d245bbaa59168d9cdc8f228f", size = 432554, upload-time = "2026-07-22T12:39:51.379Z" },
     { url = "https://files.pythonhosted.org/packages/48/3d/25e9a2d9eb6b2e8b7ca4e80a3a26cb887cce6c8e0a87c921164f11bc5574/greenlet-3.5.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7a5f095767c4493afcd06067f2bb3b8716e3f3f9e92b99c88e7e99f885b3d4d", size = 1581444, upload-time = "2026-07-22T12:25:03.818Z" },
     { url = "https://files.pythonhosted.org/packages/b9/96/4c9bf2e2c408dcc0556edce69efa9f802e82223573c53240136a086821f1/greenlet-3.5.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:42afdc1ab5f66da8c586c32af9224a74a706b4f0ea0dc3a4188a0860a09c65c9", size = 1645842, upload-time = "2026-07-22T11:51:12.295Z" },
     { url = "https://files.pythonhosted.org/packages/b5/41/303ecb26a3a56122c0f4d4073ee078881847bd6b6f463ae0ec57ec20223b/greenlet-3.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:60149df8f462d1b230038e6590c23c3b4768bb5d6c022b3b6e82532b34b0b8a3", size = 247169, upload-time = "2026-07-22T11:38:19.893Z" },
@@ -932,7 +936,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/9a/e51225dcd58713f16ccbdcc501a8da21098ea14515b7870f1f94459e5ff5/greenlet-3.5.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:24e61b88cb7e1b1d794b32a10cc346ac779681d6d74ff137a3e0a444d2bf1f02", size = 294831, upload-time = "2026-07-22T11:38:53.389Z" },
     { url = "https://files.pythonhosted.org/packages/9f/ea/de50a50fadf979713ab18b46f22ad5ff5f2dcfc637a3ebdecf669801e1a5/greenlet-3.5.4-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:870d730fec833f5a06906a32596cc099b9161594642a92a520b7a88911c95356", size = 614619, upload-time = "2026-07-22T12:26:42.282Z" },
     { url = "https://files.pythonhosted.org/packages/db/c7/2aae27fea41205b8650294c301f042a2a4bb6155eea48c995b890a92f2c1/greenlet-3.5.4-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ec5ff0d1878df6af3bf9b638a5a92a7d5693291de77c91bff10fa48519c604ef", size = 627021, upload-time = "2026-07-22T12:29:03.445Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/80/fb4d4788bbc8e54761f1fc88533af9523a6e86299fa113d6e8a8503ed9fc/greenlet-3.5.4-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:07bd44616608d873d06735b63ef1a88191d6ca57c8d291d6559c71bc14c0893c", size = 632845, upload-time = "2026-07-22T12:43:45.19Z" },
     { url = "https://files.pythonhosted.org/packages/eb/56/79fd826f9ccaae0b84e1b4ef68dabba5e105bb044ffcd448a0b782fcba9a/greenlet-3.5.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d84d993f6e575c950d91a23c1345d18fe1a4310d447bf630849d7809196b52f0", size = 624002, upload-time = "2026-07-22T11:51:11.391Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e3/6086fa578ebb72772722cdc4bcd628459814b42e0c2db1e3cbd6552b3271/greenlet-3.5.4-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:3529a8a933582ad19e224792cac7372489526576b75b4c124e8e4f29948f4861", size = 435053, upload-time = "2026-07-22T12:39:52.715Z" },
     { url = "https://files.pythonhosted.org/packages/0a/1a/27319f97e731298513dcba1a2e91b63e9d8811d9de22130f960b129b1bf1/greenlet-3.5.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:58023945f421093de5e6fa108c0985a8659d43f49e0216da25099369a121bcbd", size = 1581533, upload-time = "2026-07-22T12:25:05.322Z" },
     { url = "https://files.pythonhosted.org/packages/b1/6d/24240bf562e9786dd2799ee0a4a4dadb4ded22510f41b20245099159ac8c/greenlet-3.5.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bae2728e1897aa8df8cb1af38cd48b3a743aefe29372de7b8b7a9f532501e69f", size = 1645781, upload-time = "2026-07-22T11:51:14.805Z" },
     { url = "https://files.pythonhosted.org/packages/c1/5a/442ab1a9ef7ca6bf7210e5397a95972206a91a31033a03c8900866a10039/greenlet-3.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:ca5726c0b08ca35ae873557266a78b2c3f3b2b7d7401aa5ff886c2045dd0111c", size = 247133, upload-time = "2026-07-22T11:39:20.661Z" },
@@ -2416,6 +2422,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.62.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/5b/ca2abcf3aa69f9fb510215e3064f30b57fe57657c8d04ede45bb966d5606/playwright-1.62.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:d8da938f3748841a8754f2e1f0216902c1c8f8ae3720de8b32ccf8e6913a7c4f", size = 43732091, upload-time = "2026-07-31T17:00:44.178Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/0bfbe9904350961f4dbb713f04342e40d548c5fc26c8157bd13617c81492/playwright-1.62.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:db755ab27db21a04186f1fe8169888e42356086e439b1059b923ef417f0b6034", size = 42510842, upload-time = "2026-07-31T17:00:48.596Z" },
+    { url = "https://files.pythonhosted.org/packages/66/dc/c0486b407ad0699a250f6bbe3066fca95344009a99ca66e88ca175c69dc1/playwright-1.62.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:5108bd5b3e87169ddf269feee097da5893af7f8aea4634dfc840518d64c1f1da", size = 43732093, upload-time = "2026-07-31T17:00:52.218Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6b/b24aebc2b04bffcb342bccf96e287c78b363e1615bed5cea97500cc0393a/playwright-1.62.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:ba33bae6a13b3d9d354c751cb618af357d20fe1d57767cbcce52079bbef17ad3", size = 47748926, upload-time = "2026-07-31T17:00:56.438Z" },
+    { url = "https://files.pythonhosted.org/packages/36/43/b4b18bdc87e1949568fffdcde3ff9a0456266b2d0c6d4432cc34d89ea6eb/playwright-1.62.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db2d76613a57ad844362ce42f7d0c2fa26b19a4f7a46d4f76b891c631e6e5aff", size = 47441423, upload-time = "2026-07-31T17:01:00.404Z" },
+    { url = "https://files.pythonhosted.org/packages/81/22/af5d926fc2c32a339eec00a443644bc40ab9db1dd2dd9017873c59773c0c/playwright-1.62.0-py3-none-win32.whl", hash = "sha256:e5614fa89355d7081457680324bb219f79f69c423c5cb6fa250e30b0d8aebf1c", size = 38164450, upload-time = "2026-07-31T17:01:04.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a9/4160c1033c07af98bf841ad079457dd78408a5ee0dd56cbfe50b8b6a1c22/playwright-1.62.0-py3-none-win_amd64.whl", hash = "sha256:92c0d98ed04eb35af557b709875edba415b1f548bdb22ddb5bb3e1e6c835c2f1", size = 38164458, upload-time = "2026-07-31T17:01:08.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ec/06b55d619a7082a766aa04f2c6bb31435c87f02930087d8a0517119408fa/playwright-1.62.0-py3-none-win_arm64.whl", hash = "sha256:ea8d3055aa9d5a9f1832ac82517bd8b42c78fac7ebcbebb0107116735c8cb6a1", size = 34208868, upload-time = "2026-07-31T17:01:11.818Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2826,6 +2851,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
@@ -4034,6 +4071,7 @@ dependencies = [
     { name = "mcp" },
     { name = "openai" },
     { name = "pillow" },
+    { name = "playwright" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "qrcode" },
@@ -4083,6 +4121,7 @@ requires-dist = [
     { name = "noisereduce", marker = "extra == 'preprocess'" },
     { name = "openai", specifier = ">=1.70.0" },
     { name = "pillow", specifier = ">=11.0.0" },
+    { name = "playwright", specifier = ">=1.48.0" },
     { name = "pyannote-audio", marker = "extra == 'diarization'", specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.11.2" },
     { name = "python-dotenv", specifier = ">=1.1.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -4058,7 +4058,7 @@ wheels = [
 
 [[package]]
 name = "videonote"
-version = "0.1.22"
+version = "0.1.23"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.22"
+__version__ = "0.1.23"

--- a/videonote_mcp/cli.py
+++ b/videonote_mcp/cli.py
@@ -1831,6 +1831,13 @@ def _login_xiaohongshu_cookie(exit_on_fail: bool = True) -> None:
     print(f"{_YELLOW}⚠ {err}（配置已保存，下载时若仍失败可重试扫码）{_RESET}", file=sys.stdout)
 
 
+def _open_xiaohongshu_qr_session():
+    """官网 Chrome 扫码会话。测试可 patch 此工厂。"""
+    from app.downloaders.xiaohongshu_browser import XiaohongshuBrowserQr
+
+    return XiaohongshuBrowserQr()
+
+
 def _login_xiaohongshu_qr(exit_on_fail: bool = True) -> None:
     import time
 
@@ -1848,21 +1855,34 @@ def _login_xiaohongshu_qr(exit_on_fail: bool = True) -> None:
         QR_SUCCESS,
         XiaohongshuAuth,
     )
+    from app.downloaders.xiaohongshu_browser import BrowserQrUnavailable
 
-    auth = XiaohongshuAuth()
+    session = _open_xiaohongshu_qr_session()
     try:
-        created = auth.create_qr()
+        created = session.create_qr()
+    except BrowserQrUnavailable as e:
+        print(f"浏览器扫码不可用: {e}", file=sys.stderr)
+        print("改走直连接口（多半已被小红书拒绝）…", file=sys.stderr)
+        session = XiaohongshuAuth()
+        try:
+            created = session.create_qr()
+        except Exception as e:
+            print(f"生成二维码失败: {e}", file=sys.stderr)
+            print("请安装 Google Chrome 后重试，或 `videonote login xiaohongshu --cookie`", file=sys.stderr)
+            if exit_on_fail:
+                sys.exit(1)
+            return
     except Exception as e:
-        print(f"生成二维码失败（网络？）: {e}", file=sys.stderr)
-        print("扫不了可改用 `videonote login xiaohongshu --cookie` 粘贴 Cookie", file=sys.stderr)
+        print(f"生成二维码失败: {e}", file=sys.stderr)
+        print("请安装 Google Chrome 后重试，或 `videonote login xiaohongshu --cookie`", file=sys.stderr)
         if exit_on_fail:
             sys.exit(1)
         return
     qr_url = created.get("url") or ""
     qr_id = created.get("qr_id") or ""
     code = created.get("code") or ""
-    if not qr_url or not qr_id:
-        print("生成二维码失败：接口未返回 url/qr_id", file=sys.stderr)
+    if not qr_url:
+        print("生成二维码失败：接口未返回 url", file=sys.stderr)
         if exit_on_fail:
             sys.exit(1)
         return
@@ -1872,18 +1892,20 @@ def _login_xiaohongshu_qr(exit_on_fail: bool = True) -> None:
     print("扫不了可改用 `videonote login xiaohongshu --cookie` 粘贴 Cookie", file=sys.stdout)
     _print_ascii_qr(qr_url)
 
+    pumps = bool(getattr(session, "pumps_events", False))
     last_status = None
     try:
         for _ in range(90):
-            time.sleep(2)
+            if not pumps:
+                time.sleep(2)
             try:
-                poll = auth.poll_qr(qr_id, code)
+                poll = session.poll_qr(qr_id, code)
             except Exception as e:
                 print(f"轮询失败（网络？）: {e}", file=sys.stderr)
                 continue
             st = poll.get("code_status")
             if st == QR_SUCCESS:
-                err = auth.persist()
+                err = session.persist()
                 if err and err.startswith("未配置"):
                     print("登录成功但未取到 web_session，请改用 `videonote login xiaohongshu --cookie`", file=sys.stderr)
                     if exit_on_fail:
@@ -1914,7 +1936,9 @@ def _login_xiaohongshu_qr(exit_on_fail: bool = True) -> None:
     except KeyboardInterrupt:
         print("（已取消）", file=sys.stdout)
     finally:
-        auth.close()
+        close = getattr(session, "close", None)
+        if callable(close):
+            close()
 
 
 def _login_xiaohongshu(args, exit_on_fail: bool = True) -> None:


### PR DESCRIPTION
## Summary
- 修复 `videonote login xiaohongshu` 的 HTTP 406：edith 已拒绝旧版 x-s，扫码改走本机 Chrome/Edge 打开官网登录页（Playwright），终端仍出 ASCII 二维码。
- 无 Chrome 时回退直连接口并提示 `--cookie`。登录探测不再打会 406 的 edith `user/me`。
- 四处版本对齐到 **0.1.23**。上一版 `videonote==0.1.22` 已占用，无法覆盖；`uvx videonote@latest` 需新号。
- 合并后打 **新标签** `v0.1.23`，触发 release.yml → GitHub Release + PyPI Trusted Publishing。

## Test plan
- [x] 全量 847 passed + ruff F/I-clean
- [x] 本机 Chrome 无头拦截 `qrcode/create` 拿到 `mobile/login?qrId=...`
- [x] 四处版本字符串均为 `0.1.23`
- [ ] CI Smoke test 绿
- [ ] 合并后打 `v0.1.23` tag，确认 release.yml：四处版本一致 + PyPI 发布
- [ ] 发布后 `uvx videonote@0.1.23 login xiaohongshu` 出码（需本机 Chrome）


Made with [Cursor](https://cursor.com)