### PR TITLE
release: v0.1.25（#151 默认当前 Agent 写笔记）

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/Xiaoyuzhou/Xiaohongshu/local)",
   "author": {
     "name": "HuangYincan",

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ---
 
-VideoNote-Mcp 把「视频链接 → 多格式笔记」整条流水线打包成 **MCP Server + Claude Code Skill**：给 agent 一个链接，自动完成 下载 → 语音转写 → 画面理解 → 弹幕/评论 → AI 总结，交回一篇带截图、可整体搬迁的便携笔记。
+VideoNote-Mcp 把「视频链接 → 多格式笔记」整条流水线打包成 **MCP Server + Claude Code Skill**：给 agent 一个链接，自动完成 下载 → 语音转写 → 画面理解 → 弹幕/评论，**默认由当前对话里的 Agent 写笔记**（配置 LLM 仅当 Agent 无法看图时作为后备）。
 
 仓库：[HuangYincan/VideoNote-MCP](https://github.com/HuangYincan/VideoNote-MCP)。
 
@@ -42,7 +42,7 @@ claude plugin install videonote@videonote
 #    装完在会话里跑配置向导收尾：
 /videonote-setup
 
-# 3) （可选）LLM-Key/B 站扫码/CLI向导
+# 3) （可选）后备 LLM 的 Key / B 站扫码 / CLI 向导——默认路径不需要配置 LLM
 # ! videonote setup
 
 # 4) 重启会话，对 agent 说「帮我给这个视频做笔记」+ 链接
@@ -99,7 +99,7 @@ claude plugin install videonote@videonote
 
 <img src="assets/pipeline.svg" alt="VideoNote-Mcp 流水线地图" width="100%"/>
 
-实线为主流程：一条 `generate_note` 链接端到端跑通；虚线为可选能力（视频理解 / 弹幕评论 / Agent 生成），按需取用。各阶段细节（平台支持、引擎、参数）见 [docs/02-架构设计.md](docs/02-架构设计.md)。
+实线为主流程：一条 `prepare_note_material` 出素材，由当前对话 Agent 写笔记；`generate_note` 是后备（Agent 无法看图时走配置 LLM）。虚线为可选能力（视频理解 / 弹幕评论）。各阶段细节见 [docs/02-架构设计.md](docs/02-架构设计.md)。
 
 ## 任务管理
 
@@ -137,7 +137,7 @@ flowchart TB
 - **会议纪要**：`process_media(action="merge")` 合并分段录音 → `process_media(action="diarize")` 说话人分离 → `meeting_minutes` 风格。
 - **讲座精读**：端到端生成后，agent 基于完整字幕精修、按章节补齐细节。
 - **视频赏析**：开启弹幕 + 评论整合，笔记含「观众观点」章节。
-- **端到端**：一条链接用 `generate_note`（下载/转写/总结/评论全流程内部完成）；只准备素材用 `prepare_note_material`。
+- **默认路径**：一条链接用 `prepare_note_material`，由当前对话 Agent 写笔记；Agent 无法看图或用户要求配置 LLM 时才用 `generate_note`。只做媒体加工用 `process_media`。
 - **真实案例**：完整案例过程记录见 [`examples`](examples)。
 
 ## 如何贡献

--- a/README_EN.md
+++ b/README_EN.md
@@ -14,7 +14,7 @@
 
 ---
 
-VideoNote-Mcp packages the whole "video link → multi-format notes" pipeline into an **MCP Server + Claude Code Skill**: hand an agent a link and it automatically runs download → transcription → frame understanding → danmaku/comments → AI summary, returning a portable note with screenshots that you can move around.
+VideoNote-Mcp packages the whole "video link → multi-format notes" pipeline into an **MCP Server + Claude Code Skill**: hand an agent a link and it automatically runs download → transcription → frame understanding → danmaku/comments. **By default the current conversation agent writes the note**; the configured LLM is only a fallback when the agent cannot see images.
 
 Repository: [HuangYincan/VideoNote-MCP](https://github.com/HuangYincan/VideoNote-MCP).
 
@@ -42,7 +42,7 @@ claude plugin install videonote@videonote
 #    video-understanding / comments etc.); then run the guided config command:
 /videonote-setup
 
-# 3) (Optional) LLM key / Bilibili QR login / CLI wizard:
+# 3) (Optional) fallback LLM key / Bilibili QR login / CLI wizard — default path needs no LLM key
 # ! videonote setup
 
 # 4) Restart your session, tell the agent "make notes for this video" + link
@@ -98,7 +98,7 @@ Full run record: [`examples/note-generation-example/README.md`](examples/note-ge
 
 <img src="assets/pipeline-en.svg" alt="VideoNote-Mcp pipeline map" width="100%"/>
 
-Solid lines are the main flow: one `generate_note` link runs the whole pipeline end-to-end. Dashed lines are optional capabilities (video understanding / danmaku + comments / Agent-generated) you can opt into. Stage details (platform support, engines, parameters) live in [docs/02-架构设计.md](docs/02-架构设计.md).
+Solid lines are the main flow: `prepare_note_material` produces the pack, and the current conversation agent writes the note. `generate_note` is the fallback (configured LLM when the agent cannot see images). Dashed lines are optional capabilities (video understanding / danmaku + comments). Stage details live in [docs/02-架构设计.md](docs/02-架构设计.md).
 
 ## Task Management
 
@@ -136,7 +136,7 @@ flowchart TB
 - **Meeting minutes**: `process_media(action="merge")` to join recorded segments → `process_media(action="diarize")` for speakers → `meeting_minutes` style.
 - **Deep-reading a lecture**: after end-to-end generation, the agent refines from the full transcript, filling in section by section.
 - **Video appreciation**: enable danmaku + comment integration for an "Audience viewpoints" section.
-- **End-to-end vs decoupled**: use `generate_note` for a single link; use `prepare_note_material` for material-only and `process_media` for media operations (merge / diarize / export) when you only want part of the pipeline.
+- **Default path**: one link uses `prepare_note_material`, and the current conversation agent writes the note; use `generate_note` only when the agent cannot see images or the user asks for the configured LLM. Use `process_media` for media operations (merge / diarize / export).
 - **Real example**: full run records for both cases live in [`examples`](examples).
 
 ## How to Contribute

--- a/commands/videonote-setup.md
+++ b/commands/videonote-setup.md
@@ -26,11 +26,13 @@ description: 配置 VideoNote-MCP：体检 / LLM 供应商 / 转写引擎 / 默�
 调用 **`health_check`**，看 FFmpeg / 数据库 / 转写引擎 / whisper 模型就绪状态。
 - FFmpeg 缺失 → 先让用户安装 FFmpeg（macOS `brew install ffmpeg`，其他平台见官方包源），装完重跑。
 
-## 2. LLM 供应商（API key）
+## 2. LLM 供应商（API key，可选）
+
+默认路径由当前对话 Agent 写笔记，**不需要**配置 LLM key。仅当 Agent 无法看图（走 `generate_note` 后备）时才需要。
 
 调用 **`get_config()`**，看 `providers` 列表（id / 名称 / key 掩码）与 `app_config.default_provider_id`。
 - 已有供应商填了 key → 跳过本步。
-- 没有已填 key 的供应商 → **让用户在本会话输入**：
+- 没有已填 key 的供应商 → **告诉用户这是后备 LLM 用的**，需要时在本会话输入：
   `! videonote providers list`（看供应商 id）
   `! videonote providers set <provider_id> --api-key '...'`（填 key）
   - API key 为**隐藏输入**，值不经过对话；这一步必须由用户亲手在终端完成，不要试图用其它方式获取 key。
@@ -66,4 +68,4 @@ description: 配置 VideoNote-MCP：体检 / LLM 供应商 / 转写引擎 / 默�
 
 ---
 
-配置完成后，让用户给一条视频链接验证：`generate_note` 或「AGENT 直接生成」的 `prepare_note_material`。
+配置完成后，让用户给一条视频链接验证：默认 `prepare_note_material`（当前 Agent 写笔记）；后备 LLM 才用 `generate_note`。

--- a/docs/00-新手上路.md
+++ b/docs/00-新手上路.md
@@ -21,7 +21,7 @@ VideoNote-Mcp：把「视频 → AI Markdown 笔记」封装成 MCP server（10 
 | `app/` | **vendored 流水线** + 本仓库分叉：`services/`（note、pipeline、merge、diarization）、`downloaders/`、`transcriber/`、`gpt/`、`db/`（engine + DAO）、`utils/`、`models/`、`enmus/` | 见 `VENDOR.md` 分叉清单——再 sync 上游**不要**当「4 处补丁」重打 |
 | `skills/videonote/` | 用户侧 Skill（SKILL.md + reference/）| 改行为要同步 tools.md |
 | `.claude-plugin/` | marketplace + plugin.json（userConfig env 映射）| 加配置项要同步 plugin.json |
-| `tests/` | #150 全量验证基线为 973 个测试（#148 为 948，#149 为 963；pytest + unittest 混用，conftest 做隔离）| 新行为必须补测试 |
+| `tests/` | #151 全量验证基线为 981 个测试（#150 为 973，#149 为 963，#148 为 948；pytest + unittest 混用，conftest 做隔离）| 新行为必须补测试 |
 | `docs/` | 中文文档（本文件 + 索引 + 手册 + 审计史）| 改行为同步 04 手册 |
 | `data/` | 源码 checkout 运行时数据（SQLite、note_results、models、config，gitignored）| 安装模式在 `~/.local/share/videonote-mcp/` |
 
@@ -45,14 +45,14 @@ URL / file:// / 本地路径
   → `app/services/pipeline.py` 各步骤。工具层做**入口校验**（白名单/形状/URI 规整），
   app 层做流水线；原则 H6：入口显式校验，别等深处泛化报错。
 - **转写缓存**：同视频（`platform:video_id`）复用上次转写，按引擎分键，不重下/重转写。默认 30 天滑动 TTL + 2048MB 总量上限。
-- Agent 时序：`generate_note` → **`task` 轮询** → 读 `result.markdown`。
+- Agent 时序（#151）：默认 `prepare_note_material` → **`task` 轮询** → 读转写/帧 → 当前 Agent 写笔记。后备才是 `generate_note` / `batch_generate_notes` → 读 `result.markdown`。
 
 ## 四、开发约定（必须遵守）
 
 ### 验证三件套（每次改动后跑）
 
 ```bash
-uv run pytest -q            # 全量 948 测试（当前基线）
+uv run pytest -q            # 全量 981 测试（当前基线）
 uv run ruff check --select F .   # F 类（语法/未定义）——CI 门槛
 uv run ruff check --select I .   # import 排序——CI 门槛
 ```
@@ -110,8 +110,8 @@ docs: 回填 #N commit hash（<hash>）
 
 ## 六、当前状态（2026-09-04 基线）
 
-- **10 工具**；#150 全量验证 **973 passed, 1 skipped, 10 subtests passed**。#149 为 963；#148 为 948。
-- 最近一轮：**#150 本机 Agent 模型下的缓存治理与弹幕取消**（`note_cache` 滑动 TTL 默认 30 天 + 总量上限默认 2048MB；B 站弹幕/评论 helper 接入 `cancel_event`）。上一轮 #149（协作式取消/生命周期/迁移）；再上一轮 #148（任务成功发布、加密/DAO、manifest/ffprobe）。
+- **10 工具**；#151 全量验证 **981 passed, 1 skipped, 10 subtests passed**。#150 为 973；#149 为 963；#148 为 948。
+- 最近一轮：**#151 Skill 默认由当前 Agent 写笔记**（非多模态才走配置 LLM；`health_check.need_provider` 默认 False）。上一轮 #150 本机 Agent 缓存治理与弹幕取消。#149（协作式取消/生命周期/迁移）；#148（任务成功发布、加密/DAO、manifest/ffprobe）。
 - **部署模型**：本机 Agent（Claude Code / Codex 等）。数据目录视为当前用户受信任目录。batch 旁路普通并发上限是接受的产品语义。CLI `export --out-dir` 允许导出到桌面等任意目录，缺省仍是该任务 `note_results/{task_id}/gen/`。
 - 当前开放 P2：yt-dlp 内部 egress SSRF、manifest 清理跨进程 TOCTOU、stderr 日志路径 no-follow/owner/mode 校验——在本机 Agent 模型下不作为发布阻断；详见 `07-全库代码审查报告.md`。
 - **死代码纪律**：先跑 AST import 图 + 名字引用计数双扫描再动手；`from X import Y` 的 Y 是字符串不是 Name 节点（v1 扫描漏检过）；删函数后 grep 全仓（含 tests/CLI）确认零引用，VENDOR.md 同步，留意 dangling 装饰器/finally。

--- a/docs/02-架构设计.md
+++ b/docs/02-架构设计.md
@@ -27,7 +27,7 @@ Markdown / material
       全局索引：SQLite video_tasks（list_tasks）
 ```
 
-Agent 时序：`generate_note` 或 `prepare_note_material`（拿到 `task_id`）→ 轮询 `task`（默认 `action="status"`）→ 读 `result.markdown` / `task`（`action="transcript"`）。
+Agent 时序（#151）：默认 `prepare_note_material`（拿到 `task_id`）→ 轮询 `task` → 读转写/帧，由当前对话 Agent 写笔记。后备（Agent 无法看图或用户要求配置 LLM）才走 `generate_note` / `batch_generate_notes` → 读 `result.markdown`。
 
 ## 目录职责
 
@@ -85,14 +85,14 @@ Claude Code 插件 `userConfig` 会注入 `VIDEONOTE_*`；跳过的项可能是�
 
 | 分组 | 工具 | 要点 |
 |------|------|------|
-| 生成 | `generate_note` | `provider_id` 可省略（默认供应商 / 唯一已填 key）；认 `file://`；同视频（`platform:video_id`）复用上次转写缓存 |
-| 生成 | `prepare_note_material` | 不调 LLM；同样认 `file://`；同样吃转写缓存 |
-| 生成 | `batch_generate_notes` | 播放列表/分 P 服务端展开+逐个排队（`max_entries` 上限）；单条失败不阻断 |
+| 生成 | `prepare_note_material` | **默认路径**：不调 LLM；认 `file://`；吃转写缓存；当前 Agent 写笔记 |
+| 生成 | `generate_note` | **后备 LLM**：`provider_id` 可省略；认 `file://`；同视频复用转写缓存 |
+| 生成 | `batch_generate_notes` | **仅后备 LLM**：播放列表/分 P 服务端展开+逐个排队（`max_entries` 上限）；单条失败不阻断 |
 | 解析 | `inspect_video` | 识别平台 + 检查链接 + 拆分 P / 播放列表（#136 并入 validate_url） |
 | 任务 | `task` | action=status / transcript / cancel；未知 id → NOT_FOUND；轮询用 status，转写按需取；cancel 只发协作式事件，下一阶段边界生效，不能硬中断第三方阻塞调用；B 站弹幕/评论 helper 不接收该事件 |
 | 任务 | `list_tasks` | 列出全部任务（全局索引，带语义标题） |
 | 配置（只读） | `get_config` | `app_config` 默认值（过滤敏感项）+ `providers`（key 掩码）+ `transcriber` 就绪 + `cookie_configured`（平台名）；传 `provider_id` 附加连通性探测（用已存 key）。**修改一律走 CLI** |
-| 系统 | `health_check` | 提交前体检：ffmpeg / 磁盘 / 转写器 / 供应商 key / 模型 / 任务队列；`url` 非空时顺带预解析时长；含 `server_version` |
+| 系统 | `health_check` | 提交前体检：ffmpeg / 磁盘 / 转写器 / 任务队列；`need_provider` 默认 False；后备 LLM 传 True 才查供应商；`url` 非空时顺带预解析时长；含 `server_version` |
 | 媒体处理 | `process_media` | action=export（转写导出 srt/vtt/json）/ merge（多文件合并 16kHz mono wav）/ diarize（说话人分离；**拒绝** hf_token 参数）；同步执行，不登记任务注册表，不能用 `task(action="cancel")` 控制 |
 | 清理 | `cleanup` | 传 `task_id` 按任务清理（含 `dry_run` 先查后清）；不传 = 全局清理（同步清空全局索引；config/models 默认保留；logs 不清） |
 

--- a/docs/04-使用手册.md
+++ b/docs/04-使用手册.md
@@ -50,7 +50,7 @@
 videonote setup
 ```
 
-**方向键选择 + 高亮**、**左键返回上一级**、每步自动清屏；**不是一次性程序**，随时重跑即可改配置：① LLM 供应商（填/改 key、新增中转站、**检测连接 / 列模型 / 设默认模型**）→ ② 转写引擎 + 模型尺寸（未下载会提示下载）→ ③ 平台 Cookie（下拉选择）/ 默认笔记位置（持久化）/ **视频理解默认**（开/关 + 帧间隔秒数，持久化）/ **评论/弹幕整合默认**（开/关 + 评论条数，持久化，需 B 站 SESSDATA）/ **笔记默认**（`default_style` 默认 detailed、`default_screenshot` 默认关、`agent_direct` 默认关，持久化）—— **全自动模式**套用这些默认（会先列出完整参数清单给用户确认）。
+**方向键选择 + 高亮**、**左键返回上一级**、每步自动清屏；**不是一次性程序**，随时重跑即可改配置：① LLM 供应商（填/改 key、新增中转站、**检测连接 / 列模型 / 设默认模型**；默认路径 Agent 写笔记时 key 可选，后备 LLM 才需要）→ ② 转写引擎 + 模型尺寸（未下载会提示下载）→ ③ 平台 Cookie（下拉选择）/ 默认笔记位置（持久化）/ **视频理解默认**（开/关 + 帧间隔秒数，持久化）/ **评论/弹幕整合默认**（开/关 + 评论条数，持久化，需 B 站 SESSDATA）/ **笔记默认**（`default_style` 默认 detailed、`default_screenshot` 默认关、`agent_direct` 向导默认开；Skill 默认由当前 Agent 写笔记，server 不读此键）—— 参数不传即套这些默认。
 
 ### LLM 供应商（key 走 CLI，对话外）
 
@@ -152,7 +152,7 @@ get_config()                         # transcriber 段：当前引擎/尺寸/就
 | `VIDEONOTE_ALLOW_DESTRUCTIVE_CLEANUP` | **放行 `cleanup(include_config/include_models)`**（删 LLM key/cookie/模型，不可逆） | 关（默认拒绝，dry_run 标注「将拒绝清理」） |
 | `HF_ENDPOINT` | HuggingFace 镜像（国内下载慢/卡时用） | 官方 `https://huggingface.co`；国内可 `https://hf-mirror.com` |
 
-**会话内有限并发 + 多会话并行**：每个 Claude Code 会话独立起一个 MCP server 进程。普通 `generate_note` / `prepare_note_material` 受 `VIDEONOTE_MAX_WORKERS`（默认 3）admission 限制，提交时在锁内预占名额，覆盖排队与执行全生命周期，超限会拒绝新提交；**`batch_generate_notes` 单次最多提交 50 条，绕过普通 admission，由线程池排队**，不建议并发调用多个 batch 以免队列堆积。**多个会话**可各自并行（互不干扰）。**注意**：Claude Code 客户端对「同一条消息里多个并行 MCP 工具调用」处理不稳（最后一个响应会卡死、任务也未提交）—— **不要在同一消息里并行塞多个 `generate_note`**。**多任务轮询请用轻量 `task(task_id)`**。需要取消用 `task(task_id, action="cancel")`。whisper / MLX 转写吃 CPU/内存；所有会话共用同一个 SQLite。
+**会话内有限并发 + 多会话并行**：每个 Claude Code 会话独立起一个 MCP server 进程。普通 `generate_note` / `prepare_note_material` 受 `VIDEONOTE_MAX_WORKERS`（默认 3）admission 限制，提交时在锁内预占名额，覆盖排队与执行全生命周期，超限会拒绝新提交；**`batch_generate_notes` 仅用于后备 LLM 的合集**，单次最多提交 50 条，绕过普通 admission，由线程池排队。**多个会话**可各自并行（互不干扰）。**注意**：Claude Code 客户端对「同一条消息里多个并行 MCP 工具调用」处理不稳—— **不要在同一消息里并行塞多个 `generate_note` / `prepare_note_material`**。**多任务轮询请用轻量 `task(task_id)`**。需要取消用 `task(task_id, action="cancel")`。whisper / MLX 转写吃 CPU/内存；所有会话共用同一个 SQLite。
 
 **协作式取消边界（#149/#150）**：对 `generate_note` / `prepare_note_material` 调用 `task(task_id, action="cancel")` 后，取消事件会沿平台字幕、下载、ASR、音频预处理、ffmpeg、VideoReader 抽帧、说话人分离、B 站弹幕/评论聚合和笔记后处理的检查点传播。运行中的任务返回 `CANCELLING`，由 worker 在下一阶段边界捕获 `TaskCancelledError` 后写 `CANCELLED`；排队中的任务可直接取消。取消不是线程/进程硬中断；正在进行的 HTTP/模型推理只能等自然返回。
 
@@ -171,14 +171,14 @@ MCP 工具面可被 Agent 以任意输入驱动，防被不可信内容诱导「
 
 | 工具 | 参数要点 | 返回要点 |
 |------|----------|----------|
-| `generate_note` | `video_url`（必填，认 `file://`）、`platform`（可省略）、`quality`、`model_name`、`provider_id`（可省略：默认供应商或唯一已填 key）、`format`、`style`、`extras`、`screenshot`、`link`、`video_understanding`、`video_interval`、`grid_size`、`include_comments`、`comments_limit`、`notes_dir` | `{task_id}` |
-| `prepare_note_material` | `video_url`（必填）、`platform`、`video_understanding`、`video_interval`、`grid_size`、`include_comments`、`comments_limit` | **只准备素材、不调用配置 LLM**；`{task_id}`，`task` 轮询到 SUCCESS 时 `result` = 素材包：`{kind:"material", title, transcript:{language, full_text, segments}, frames:[file://...jpg], comments_danmaku, video_path, audio_path}` —— 供 **AGENT 直接生成**（agent_direct） |
-| `batch_generate_notes` | `video_url`（必填，B 站分 P / YouTube 播放列表等可展开链接）、`max_entries`(默认 10)、其余参数同 `generate_note`（批量共享同一套风格/格式） | 服务端展开条目并逐个排队（单次最多 50 条；绕过普通 admission，由线程池排队）：`{ok, total, submitted, truncated?, errors, tasks:[{p,title,duration,url,task_id,status}]}`；单条失败不阻断，全部失败 `ok=false` |
-| `inspect_video` | `url`、`platform?` | 只解析：B 站分 P / YouTube 播放列表 → `{kind, entries:[{p,title,url}]}`，url 可直接 `generate_note` |
+| `generate_note` | `video_url`（必填，认 `file://`）、`platform`（可省略）、`quality`、`model_name`、`provider_id`（可省略：默认供应商或唯一已填 key）、`format`、`style`、`extras`、`screenshot`、`link`、`video_understanding`、`video_interval`、`grid_size`、`include_comments`、`comments_limit`、`notes_dir` | **后备 LLM**：`{task_id}` |
+| `prepare_note_material` | `video_url`（必填）、`platform`、`video_understanding`、`video_interval`、`grid_size`、`include_comments`、`comments_limit` | **默认路径**：只准备素材、不调用配置 LLM；`{task_id}`，`task` 轮询到 SUCCESS 时 `result` = 素材包：`{kind:"material", title, transcript:{language, full_text, segments}, frames:[file://...jpg], comments_danmaku, video_path, audio_path}` —— 供当前对话 Agent 写笔记 |
+| `batch_generate_notes` | `video_url`（必填，B 站分 P / YouTube 播放列表等可展开链接）、`max_entries`(默认 10)、其余参数同 `generate_note`（批量共享同一套风格/格式） | **仅后备 LLM**：服务端展开条目并逐个排队（单次最多 50 条；绕过普通 admission，由线程池排队）。默认路径合集用每集 `prepare_note_material` |
+| `inspect_video` | `url`、`platform?` | 只解析：B 站分 P / YouTube 播放列表 → `{kind, entries:[{p,title,url}]}`，url 可直接 `prepare_note_material` / `generate_note` |
 | `task` | `task_id`、`action`（status/transcript/cancel，默认 status）、`segment_range` | status：`{status, message, result?}`；只有 `result.json` 与 manifest 已持久化后才发布 SUCCESS，SUCCESS 时 `result.markdown`（或素材包结果，见 `prepare_note_material`）；**note 任务默认不含完整转写**（避免撑爆 context），要转写用 `action="transcript"`；**素材包任务的转写是主产物，默认直接返回**。transcript：读已完成任务转写（不耗 LLM，按需取）：`{ok, language, segments, full_text, meta}`（默认前 50 段，`"all"` 全文 / `"50-"` / `"0-50"` 按段切片，`meta.truncated` 续取）。cancel：取消进行中/排队的任务（协作式，下一阶段边界生效；运行中返回 `CANCELLING`，排队中可直接 `CANCELLED`，不能硬中断第三方阻塞调用） |
 | `list_tasks` | — | 列出全部任务（全局索引），`[{task_id, title, status, summary, platform, created_at, note_dir}]`，按语义标题识别 |
 | `get_config` | `provider_id`(可选) | **只读配置汇总**：`app_config` 默认值(过滤敏感项) + `providers`(key 掩码) + `transcriber`(引擎/尺寸/就绪) + `cookie_configured`(平台名) + `note_cache`(ttl_days/max_mb)；传 `provider_id` 附加连通性探测。**配置修改一律走 CLI**（`! videonote providers set/transcriber set/login bilibili/login xiaoyuzhou/login xiaohongshu`） |
-| `health_check` | `url?`、`provider_id?`、`need_provider`(默认 True) | `server_version` / ffmpeg / 磁盘剩余 / db / 转写器 / keyed_providers / 任务队列；提交前体检，`url` 非空时顺带预解析时长；只做素材包（不调 LLM）时 `need_provider=False` 跳过供应商检查 |
+| `health_check` | `url?`、`provider_id?`、`need_provider`(默认 False) | `server_version` / ffmpeg / 磁盘剩余 / db / 转写器 / keyed_providers / 任务队列；提交前体检，`url` 非空时顺带预解析时长；默认路径不查供应商；走 `generate_note` 后备时 `need_provider=True` |
 | `process_media` | `action`（export/merge/diarize）、`task_id`（export）、`formats`（srt/vtt/json，缺省取 setup「导出格式默认」）、`files`（merge，≥2 个本地路径）、`audio_file`（diarize）、`num_speakers`（diarize，可选）、`out_dir`(可选) | export：确定性导出转写（不耗 LLM），返回 `{task_id, formats:{fmt:"file://路径"}}`；merge：FFmpeg concat 合并多文件为 16kHz mono wav，返回 `{ok, path}`；diarize：说话人分离（pyannote 可选重依赖），**拒绝 hf_token 参数**，token 走 env / setup。该工具保持同步执行，不进入任务注册表，不能通过 `task(action="cancel")` 控制 |
 | `cleanup` | `task_id?`、`include_note`(默认 False)、`include_config`(默认 False)、`include_models`(默认 False)、`dry_run`(默认 False) | 传 `task_id` 按任务清理（删该任务中间产物；`include_note=True` 删整个任务文件夹+索引）；不传 = 全局清空 note_results/static（恢复出厂）+ 清空全局索引；`logs/` 刻意不清（进程持有 fd）；`include_config=True`/`include_models=True` 才清 config/models（**默认拒绝，需 `VIDEONOTE_ALLOW_DESTRUCTIVE_CLEANUP=1` 放行**，#142）；**`dry_run=True` 只预览不删**（#137 行为安全；未放行时对 config/models 标注「将拒绝清理」） |
 
@@ -281,28 +281,30 @@ generate_note(video_url=..., ..., screenshot=True, format=["screenshot"])
 
 ## Agent 工作流
 
-一次典型的「给视频做笔记」：**默认全自动，不要先问模式**。
+一次典型的「给视频做笔记」：**默认由当前对话 Agent 写笔记**，不要先问模式。
 
-1. `health_check` —— ffmpeg/db；`keyed_providers=0` 则让用户 `! videonote providers set`。
+1. `health_check(need_provider=False)` —— ffmpeg/db；**不要**因为 `keyed_providers=0` 去要 API key。
 2. `inspect_video`（识别平台 + 检查链接 + 拆多集）。
-3. `generate_note(video_url=...)`（`provider_id` 可省略，套 setup 默认）。
+3. `prepare_note_material`（能看图时开 `video_understanding` 抽帧）。
 4. `task` 轮询到终态。
-5. 呈现 `result.markdown`。细节用 `task(action="transcript")`（默认前 50 段，全文 `"all"`）。
+5. `task(action="transcript")` + Read `frames` → **你写 Markdown**。有弹幕/评论加「观众观点」。
 6. **不要主动问后续优化**；用户要精修再改。
 
-用户明确说「手动 / 我要选参数」才逐项问。多集（合集/分P/播放列表）一条 `batch_generate_notes`：单次最多 50 条，绕过普通任务 admission，由线程池排队执行；不要并发调用多个 batch，以免队列堆积。互相独立的多个链接才用 subagent。不要同一消息里并行多个 `generate_note`。
+**后备 LLM**（仅当你无法看图，或用户明确要求配置 LLM）：`health_check(need_provider=True)` → 单集 `generate_note` / 合集 `batch_generate_notes` → 呈现 `result.markdown`。
+
+用户明确说「手动 / 我要选参数」才逐项问。合集默认逐条 `prepare_note_material`（admission 默认 3）；互相独立的多个链接用 subagent。不要同一消息里并行多个 `generate_note` / `prepare_note_material`。
 
 示例：
 
 > 用户：帮我给这个视频做个笔记 https://www.youtube.com/watch?v=xxxx
 >
-> agent：`inspect_video` → `{ok:true, platform:"youtube", kind:"single"}`；直接 `generate_note` → 轮询 → 展示 Markdown。
+> agent：`inspect_video` → `{ok:true, platform:"youtube", kind:"single"}`；`prepare_note_material` → 轮询 → 读转写/帧 → 写 Markdown。
 
-## 手动模式 + AGENT 直接生成
+## 手动模式 + 后备 LLM
 
-- **默认**：全自动，参数不传即套 setup / userConfig。
-- **手动**（用户要求）：再问模型、风格、视频理解、评论、截图。
-- **AGENT 直接生成**（用户明确要「你自己写」/`agent_direct`）：`prepare_note_material` → 轮询 → `task(action="transcript")`（默认前 50 段）+ Read `frames` → agent 自己写 Markdown（有弹幕/评论加「观众观点」）。不是默认。
+- **默认**：当前 Agent 写笔记；`health_check` 默认不查供应商。
+- **手动**（用户要求）：再问风格、视频理解、评论、截图（后备路径再问模型）。
+- **后备 LLM**（无法看图 / 用户要求配置 LLM）：`generate_note` 或合集 `batch_generate_notes`。`agent_direct` 配置键 server 不读。
 
 ## Skill 使用
 

--- a/docs/05-优化清单.md
+++ b/docs/05-优化清单.md
@@ -1640,3 +1640,18 @@ issue #32（悬空 `@staticmethod` 误绑 `_init_transcriber`，用户报障）�
 #### 测试
 
 新增/更新：`tests/test_note_cache.py`（CacheLimitsTest）、`tests/test_cancellation_pipeline.py`、`tests/test_pipeline_steps.py`、`tests/test_bilibili_comment.py`、`tests/test_server_contracts.py`（get_config.note_cache）。全量：**973 passed, 1 skipped, 10 subtests passed + ruff F/I-clean**（963 → 973）。
+
+### ✅ 151. Skill 默认由当前 Agent 写笔记，非多模态才走配置 LLM（2026-09-04 登记）
+
+产品决定：大多数情况由当前对话 Agent 写笔记；仅当该 Agent 无法看图（纯文本 / 无视觉），或用户明确要求配置 LLM 时，才走 `generate_note` / `batch_generate_notes`。
+
+#### 已实施
+
+- **✅ SKILL 默认路径**：`health_check(need_provider=False)` → `inspect_video` → `prepare_note_material`（能看图则抽帧）→ 读转写/帧 → Agent 写 Markdown。合集默认逐条 prepare（admission 3）；独立链接各 subagent。**不要**对默认路径用 `batch_generate_notes`。
+- **✅ 后备路径**：无法看图 / 用户要求配置 LLM → `health_check(need_provider=True)` → 单集 `generate_note`、合集 `batch_generate_notes`。
+- **✅ `health_check.need_provider` 默认 False**：避免默认路径被「无已填 key 的供应商」误拦。走后备时显式传 True。
+- **✅ 工具 docstring / preflight 合集提示 / CLI 向导文案**与 Skill 对齐。`agent_direct` 仍 server 不读；旧向导默认关，Skill 忽略 false。
+
+#### 测试
+
+新增 `tests/test_151_batch.py`；更新 `test_server_contracts.py` PreflightNeedProviderTest。全量：**981 passed, 1 skipped, 10 subtests passed + ruff F/I-clean**（973 → 981）。

--- a/docs/05-优化清单.md
+++ b/docs/05-优化清单.md
@@ -1641,7 +1641,7 @@ issue #32（悬空 `@staticmethod` 误绑 `_init_transcriber`，用户报障）�
 
 新增/更新：`tests/test_note_cache.py`（CacheLimitsTest）、`tests/test_cancellation_pipeline.py`、`tests/test_pipeline_steps.py`、`tests/test_bilibili_comment.py`、`tests/test_server_contracts.py`（get_config.note_cache）。全量：**973 passed, 1 skipped, 10 subtests passed + ruff F/I-clean**（963 → 973）。
 
-### ✅ 151. Skill 默认由当前 Agent 写笔记，非多模态才走配置 LLM（2026-09-04 登记）
+### ✅ 151. Skill 默认由当前 Agent 写笔记，非多模态才走配置 LLM（2026-09-04 登记；实现已合入 `f027229`）
 
 产品决定：大多数情况由当前对话 Agent 写笔记；仅当该 Agent 无法看图（纯文本 / 无视觉），或用户明确要求配置 LLM 时，才走 `generate_note` / `batch_generate_notes`。
 

--- a/docs/06-执行进度.md
+++ b/docs/06-执行进度.md
@@ -430,3 +430,12 @@
 - [x] **缓存 TTL/LRU**：`VIDEONOTE_CACHE_TTL_DAYS` 默认 30（滑动）、`VIDEONOTE_CACHE_MAX_MB` 默认 2048；promote 后淘汰过期与超量身份目录；命中刷新 mtime。
 - [x] **弹幕/评论取消**：helper 接 `cancel_event`，取消错误不吞掉。
 - [x] **契约**（commit `1eb6308`）：插件 userConfig、`get_config.note_cache`、CLI `--out-dir` help、活跃文档与 Skill 同步。全量 **973 passed, 1 skipped, 10 subtests passed**；Ruff F/I 与 `git diff --check` 通过。
+
+## 批 42：#151 Skill 默认由当前 Agent 写笔记（2026-09-04）
+
+产品决定：默认当前对话 Agent 写笔记；仅非多模态（或用户要求配置 LLM）才走 `generate_note` / `batch_generate_notes`。
+
+- [x] **SKILL / reference / 手册**：默认 `prepare_note_material`；合集逐条 prepare；`batch_generate_notes` 降为后备。
+- [x] **health_check**：`need_provider` 默认 False；合集 duration 提示改默认 prepare。
+- [x] **CLI 向导**：Agent 写笔记确认项默认开；忽略旧 `agent_direct=false` 作为分流依据。
+- [x] **契约**：`tests/test_151_batch.py` + PreflightNeedProviderTest 默认跳过供应商检查。全量 **981 passed, 1 skipped, 10 subtests passed**；Ruff F/I 与 `git diff --check` 通过。

--- a/docs/06-执行进度.md
+++ b/docs/06-执行进度.md
@@ -438,4 +438,4 @@
 - [x] **SKILL / reference / 手册**：默认 `prepare_note_material`；合集逐条 prepare；`batch_generate_notes` 降为后备。
 - [x] **health_check**：`need_provider` 默认 False；合集 duration 提示改默认 prepare。
 - [x] **CLI 向导**：Agent 写笔记确认项默认开；忽略旧 `agent_direct=false` 作为分流依据。
-- [x] **契约**：`tests/test_151_batch.py` + PreflightNeedProviderTest 默认跳过供应商检查。全量 **981 passed, 1 skipped, 10 subtests passed**；Ruff F/I 与 `git diff --check` 通过。
+- [x] **契约**（commit `f027229`）：`tests/test_151_batch.py` + PreflightNeedProviderTest 默认跳过供应商检查。全量 **981 passed, 1 skipped, 10 subtests passed**；Ruff F/I 与 `git diff --check` 通过。

--- a/docs/07-全库代码审查报告.md
+++ b/docs/07-全库代码审查报告.md
@@ -152,6 +152,6 @@
 
 文首「不宣称已重新跑完整测试套件」仅描述 #149 文档回填当时的口径；#149 最终合并与后续 #150 的全量结果分别记在第 3 节与 `docs/06` 批 41。
 
-## 10. #151 补充（2026-09-04，Skill 默认 Agent 写笔记）
+## 10. #151 补充（2026-09-04，Skill 默认 Agent 写笔记，commit `f027229`）
 
 用户契约改为：默认路径是当前对话 Agent 写笔记（`prepare_note_material`）；`generate_note` / `batch_generate_notes` 仅在 Agent 无法看图或用户明确要求配置 LLM 时使用。`health_check.need_provider` 默认 False。`agent_direct` 配置键仍 server 不读。

--- a/docs/07-全库代码审查报告.md
+++ b/docs/07-全库代码审查报告.md
@@ -151,3 +151,7 @@
 - P2-01/02/03 与 P3-01 不在本机 Agent 模型下继续实施。
 
 文首「不宣称已重新跑完整测试套件」仅描述 #149 文档回填当时的口径；#149 最终合并与后续 #150 的全量结果分别记在第 3 节与 `docs/06` 批 41。
+
+## 10. #151 补充（2026-09-04，Skill 默认 Agent 写笔记）
+
+用户契约改为：默认路径是当前对话 Agent 写笔记（`prepare_note_material`）；`generate_note` / `batch_generate_notes` 仅在 Agent 无法看图或用户明确要求配置 LLM 时使用。`health_check.need_provider` 默认 False。`agent_direct` 配置键仍 server 不读。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -877,3 +877,10 @@ v0.1.1 → v0.1.2 的主要变更（详见下方各「维护」节点块；稳�
 - **导出**：CLI 缺省仍写任务 `gen/`，`--out-dir` 可指定桌面；MCP 导出仍受数据目录门禁。
 - **明确不做**：yt-dlp 内部 SSRF、跨进程 manifest TOCTOU、stderr no-follow、batch 全局背压（本机 Agent 模型 / 已接受的产品语义）。
 - **验证**：全量 `pytest` **973 passed, 1 skipped, 10 subtests passed**；Ruff F/I、`git diff --check` 通过。
+
+## Wave 批 42（2026-09-04 · #151 Skill 默认当前 Agent 写笔记）
+
+- **默认路径**：给链接 → `prepare_note_material` → 当前对话 Agent 读转写/帧写笔记。不需要配置 LLM key。
+- **后备**：仅当 Agent 无法看图，或用户明确要求配置 LLM → `generate_note` / 合集 `batch_generate_notes`。
+- **health_check**：`need_provider` 默认 False；合集预解析提示改为默认 prepare。
+- **验证**：全量 `pytest` **981 passed, 1 skipped, 10 subtests passed**；Ruff F/I、`git diff --check` 通过。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -878,7 +878,7 @@ v0.1.1 → v0.1.2 的主要变更（详见下方各「维护」节点块；稳�
 - **明确不做**：yt-dlp 内部 SSRF、跨进程 manifest TOCTOU、stderr no-follow、batch 全局背压（本机 Agent 模型 / 已接受的产品语义）。
 - **验证**：全量 `pytest` **973 passed, 1 skipped, 10 subtests passed**；Ruff F/I、`git diff --check` 通过。
 
-## Wave 批 42（2026-09-04 · #151 Skill 默认当前 Agent 写笔记）
+## Wave 批 42（2026-09-04 · #151 Skill 默认当前 Agent 写笔记，commit `f027229`）
 
 - **默认路径**：给链接 → `prepare_note_material` → 当前对话 Agent 读转写/帧写笔记。不需要配置 LLM key。
 - **后备**：仅当 Agent 无法看图，或用户明确要求配置 LLM → `generate_note` / 合集 `batch_generate_notes`。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote"
-version = "0.1.24"
+version = "0.1.25"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/skills/videonote/SKILL.md
+++ b/skills/videonote/SKILL.md
@@ -5,49 +5,64 @@ description: 用 VideoNote-Mcp 的 MCP 工具把视频链接/本地视频（B站
 
 # VideoNote-Mcp —— 视频 → AI 笔记
 
-## 默认路径（给个链接就跑）
+笔记默认由**当前对话里的你**写。配置 LLM（`generate_note` / `batch_generate_notes`）是后备。
 
-用户没说「手动 / 我要选参数 / AGENT 自己写」时，**不要先问全自动还是手动，不要列 6 项等确认**：
+**判定（自己做，不要问用户）**：
+- 你能阅读图片（对本对话中的图片 / `file://` 帧做 Read 能看到画面）→ **默认路径**。
+- 你是纯文本模型、Read 图片只能得到路径或报错、或宿主无视觉 → **后备 LLM**。
+- 用户明确说「用配置的 LLM / generate_note / 全自动 LLM / 不要你自己写」→ **后备 LLM**（即使你能看图）。
+
+不要先问全自动还是手动，不要列 6 项等确认。`get_config` 里的 `agent_direct` **server 不读**；旧向导默认关，**不要**因为该键是 false 就改走 `generate_note`。
+
+## 默认路径（你来写）
 
 1. 没有 `mcp__videonote__*` → 停，让用户重启会话 / `/reload-plugins`。不要用 CLI 代替 MCP。
-2. `health_check`：缺 ffmpeg 先让用户装。`keyed_providers=0` 且用户要 AI 笔记 → 让用户 `! videonote providers set`（key 不进对话）。
+2. `health_check(need_provider=False)`：缺 ffmpeg 先让用户装。**不要**因为 `keyed_providers=0` 去要 API key。
 3. `inspect_video(url)`（识别平台 + 检查链接 + 拆多集；链接无效会直接给原因）。
-4. `kind=multi`（合集 / 分 P / 播放列表）→ 一条 `batch_generate_notes` 全出笔记。
-   - `kind=single`：一条 url。
-   - `kind=multi`：每条 `entries[].url` 当独立视频。用户没说「只要第 N 集」就处理全部（太多先报 `total`，问要不要只跑 `current_p`）。
-     要全出笔记 → 一条 `batch_generate_notes(url)` 服务端逐个排队（省去逐条 subagent，见规则 2）。
-5. 长视频 / 首次使用 / 最近改过转写引擎 → `health_check(url)` 体检（ffmpeg/磁盘/转写器/供应商 key，`ok=false` 先修）。
-6. 直接 `generate_note(video_url)`（`provider_id` 可省略）。参数不传 = setup / userConfig 默认。
-   - **转写素材自动优先平台官方字幕**（YouTube/B 站人工+自动字幕 / 小宇宙官方文稿）——有官方字幕的视频不会走本地转写引擎；无字幕/获取失败才下载音轨转写。用户问「为什么走/没走转写引擎」先看该视频有无官方字幕。小宇宙官方文稿需用户先 `! videonote login xiaoyuzhou`（终端扫码）。
-7. **`task(task_id)` 轮询**到 SUCCESS / FAILED / CANCELLED。等待中可用 `stage` / `elapsed_secs` 报进度（如「转写中，已 3 分钟」）。取消是协作式：可控下载/ffmpeg 会尽快终止；B 站弹幕/评论会在下一请求边界停止，正在进行的 HTTP 仍要等返回，不要向用户承诺立即硬停。
-8. 呈现 `result.markdown`（要点 + 章节 + 原文链接）。用户要细节再用 `task(task_id, action="transcript")`（默认前 50 段；全文 `segment_range="all"`）。
-9. **不要主动问「要不要后续优化」**。用户要精修再读笔记 + 转写改。
+4. `kind=single`：一条 `prepare_note_material`。你能看图时传 `video_understanding=True`（抽帧给你 Read）。
+   `kind=multi`：每条 `entries[].url` 各自 `prepare_note_material`（用户没说「只要第 N 集」就处理全部；太多先报 `total`）。
+   **互相独立的多个链接**：每个 url 一个 **subagent**（提交 → 轮询 → 读素材 → 写笔记 → 汇报），主 agent 汇总。
+   **合集 / 分 P / 播放列表**：同一会话逐条提交（admission 默认 3，超限会拒；先提交最多 3 个，完成再下一批）。不要同一消息并行多个 `prepare_note_material`。**不要**对默认路径用 `batch_generate_notes`。
+5. 长视频 / 首次使用 / 最近改过转写引擎 → `health_check(need_provider=False, url=url)`。
+6. **`task(task_id)` 轮询**到 SUCCESS / FAILED / CANCELLED。取消是协作式：可控下载/ffmpeg 会尽快终止；B 站弹幕/评论会在下一请求边界停止，正在进行的 HTTP 仍要等返回，不要向用户承诺立即硬停。
+7. `task(task_id, action="transcript")`（默认前 50 段；全文 `segment_range="all"`）+ Read `frames` → **你写 Markdown**。有 `comments_danmaku` 加「观众观点」一节（不捏造）。
+8. 呈现笔记。用户要细节再用 transcript。**不要主动问「要不要后续优化」**。用户要精修再读笔记 + 转写改。
 
 用户改某一项（风格 / 视频理解 / 评论 / 截图）→ 只改那一项再跑。用户说「手动」才逐项问（见 reference）。
+
+## 后备路径（配置 LLM）
+
+仅当你**不能看图**，或用户明确要求配置 LLM：
+
+1. `health_check(need_provider=True)`：`keyed_providers=0` → 让用户 `! videonote providers set`（key 不进对话）。
+2. 单集：`generate_note(video_url)`（`provider_id` 可省略，套 setup 默认）。合集 / 分 P / 播放列表：一条 `batch_generate_notes`（单次最多 50 条，服务端排队，**不要并发多个 batch**）。
+3. **`task(task_id)` 轮询**到终态，呈现 `result.markdown`。
+4. **转写素材自动优先平台官方字幕**（YouTube/B 站人工+自动字幕 / 小宇宙官方文稿）；无字幕才走本地转写。小宇宙官方文稿需先 `! videonote login xiaoyuzhou`。
 
 ## 强制规则
 
 1. **必须用 MCP 工具**。凭证例外：本会话 `! videonote providers set`、`! videonote login bilibili`、`! videonote login xiaoyuzhou`、`! videonote login xiaohongshu`。
-2. **单视频一回合一个提交**。**合集 / 分 P / 播放列表**（inspect_video `kind=multi`）：一条 `batch_generate_notes` 服务端展开并逐条排队，单次最多 50 条；它绕过普通 `generate_note` admission，由线程池排队，**不要并发调用多个 batch**。普通 `generate_note` / `prepare_note_material` 在提交锁内预占名额，预占覆盖排队和执行全生命周期，超限拒绝。**互相独立的多个链接**：每个 url 一个 **subagent**（提交 → 轮询 → 汇报），主 agent 汇总。不要在同一条消息里并行多个 `generate_note`。
-3. **AGENT 自己写笔记**（用户明确要 `agent_direct` / 「你自己写」）：`prepare_note_material` → 轮询 → `task(task_id, action="transcript")` + Read `frames` → 你写 Markdown。有 `comments_danmaku` 加「观众观点」一节（不捏造）。这是可选分支，不是默认。
-4. **handoff**：只有返回 `handoff: true`（或 generic **下载失败**）才接手。未知 URL 现在是 `generic`（yt-dlp），**不要**一看到非内置平台就当失败。接手：WebFetch / 浏览器取源，或下到本地再 `generate_note(platform="local")`。
+2. **单视频一回合一个提交**。不要在同一条消息里并行多个 `generate_note` / `prepare_note_material`（客户端不稳）。普通任务在提交锁内预占名额，覆盖排队和执行全生命周期，超限拒绝。`batch_generate_notes` 只用于后备 LLM 的合集/播放列表，绕过普通 admission，由线程池排队。
+3. **默认你自己写笔记**（见上）。后备才走配置 LLM。
+4. **handoff**：只有返回 `handoff: true`（或 generic **下载失败**）才接手。未知 URL 现在是 `generic`（yt-dlp），**不要**一看到非内置平台就当失败。接手：WebFetch / 浏览器取源，或下到本地再 `prepare_note_material` / `generate_note(platform="local")`。
 5. **API key / Cookie / HF token 绝不进对话或 MCP 参数。**
 6. **`process_media` 保持同步**：export / merge / diarize 不登记后台任务注册表，没有可供 `task(action="cancel")` 控制的任务；需要取消时不要承诺能硬中断其第三方阻塞调用。
 
-## 工作流（默认 = 配置 LLM）
+## 工作流
 
 ```
-health_check → (必要时 inspect_video / health_check(url)) → generate_note
-    → task 直到终态 → 呈现 markdown
+默认：health_check(need_provider=False) → inspect_video → prepare_note_material
+      → task 直到终态 → 读转写/帧 → 你写 Markdown
+后备：health_check(need_provider=True) → generate_note | batch_generate_notes
+      → task 直到终态 → 呈现 result.markdown
 ```
 
-- 视频理解 / 弹幕评论 / 截图：用户提起或 setup 已开才传参。
-- 多集（合集/分P/播放列表）：一条 `batch_generate_notes`（单次最多 50 条，由线程池排队）；互相独立的链接才各自 subagent。
+- 视频理解 / 弹幕评论 / 截图：默认路径你能看图就开抽帧；其余用户提起或 setup 已开才传参。
 - 输出格式、合并音频、说话人分离：用户要时再做（见 `reference/tools.md` / `output-formats.md`）。
 
 ## 配置
 
-- 首次：`/videonote-setup`。默认值来自插件 userConfig 或 `! videonote setup`。
+- 首次：`/videonote-setup`。默认路径不需要配置 LLM key；后备路径才需要。
 - Skill 和 MCP 对不上：`health_check.skill_refresh` 里的 disable + install。
 
 ## 参考

--- a/skills/videonote/reference/tools.md
+++ b/skills/videonote/reference/tools.md
@@ -5,6 +5,7 @@
 ## 生成笔记
 
 ### `generate_note(video_url, platform?, quality?, provider_id?, model_name?, format?, style?, screenshot?, link?, video_understanding?, video_interval?, grid_size?, notes_dir?, extras?, include_comments?, comments_limit?)`
+- **后备路径**：用配置 LLM 异步生成笔记。当前对话 Agent 无法看图，或用户明确要求配置 LLM 时才用。默认路径是 `prepare_note_material` + Agent 自己写。
 - 提交视频，异步生成，返回 `{task_id, status: "PENDING", platform, model_name}`。
 - **同视频（`platform:video_id`）再次生成会复用上次转写缓存**（`note_cache`，按引擎/尺寸分键），不再重下+重转写；命中时音频也从缓存复制到新任务，`audio_path` 指向真实文件。缓存默认 30 天滑动 TTL + 2048MB 总量上限。`cleanup`（全局清理）会清缓存。
 - `quality`: fast / medium / slow。
@@ -14,17 +15,17 @@
 - `include_comments=True` + `comments_limit`（默认 20）：整合 B 站弹幕+评论（需 SESSDATA；失败不阻断）。弹幕/评论 helper 在请求边界检查 `cancel_event`；正在进行的 HTTP 仍要等返回。
 - `screenshot=True`：插截图，产出便携笔记 note.md + Assets/（相对引用）。**布尔开关与 `format` 双向闭合（#120）**：`screenshot=True` 自动并入 `format`（否则 prompt 不注入标记指令 → LLM 不输出 `*Screenshot-[mm:ss]` → 视频白下载但笔记无图）；`format=["screenshot"]` 等价（即使布尔省略也会下载视频做截图）。`link=True` 同理自动并入 `format`。
 - `notes_dir`: 便携笔记目录（指定即写 note.md，即使不插图片；支持 `file://` URI）。**安全边界**：数据目录外（含 env `VIDEONOTE_NOTES_DIR` 兜底）默认拒绝，需 `VIDEONOTE_ALLOW_EXTERNAL_PATHS=1`/插件 `allow_external_paths` 放行（#142）——报错即说明放行方式，转告用户即可。
-- **并发上限 `VIDEONOTE_MAX_WORKERS`（默认 3）**：普通 `generate_note` / `prepare_note_material` 在提交锁内预占名额，预占覆盖排队与执行全生命周期，超限会拒绝。**`batch_generate_notes` 通过 thread-local bypass 不占普通 admission 名额，由线程池排队**，单次最多 50 条；不要在同一条消息里并行塞多个 `generate_note`（客户端不稳），也不要并发调用多个 batch。`provider_id` 可省略。
+- **并发上限 `VIDEONOTE_MAX_WORKERS`（默认 3）**：普通 `generate_note` / `prepare_note_material` 在提交锁内预占名额，预占覆盖排队与执行全生命周期，超限会拒绝。**`batch_generate_notes` 仅后备 LLM**，通过 thread-local bypass 不占普通 admission 名额，由线程池排队，单次最多 50 条；不要在同一条消息里并行塞多个 `generate_note` / `prepare_note_material`（客户端不稳），也不要并发调用多个 batch。`provider_id` 可省略。
 
 ### `inspect_video(url, platform?)`
 - **只解析、不下载、不提交**。B 站分 P / YouTube 播放列表 / 单集。
 - 返回 `{ok, platform, kind: single|multi, title, current_p?, total, truncated, entries:[{p, title, duration, url, video_id}]}`。
-- `kind=multi`：用户只要一集 → 直接用对应那条 `entries[].url` 按单集流程提交；要全出 → 用 `batch_generate_notes`（服务端逐个排队，见下）。**不要逐条 subagent 提交**——并发上限 3，逐条会被拒。超过 200 条 `truncated=true`。
-- **批量**：多集要全出笔记用 `batch_generate_notes(url, max_entries=10)` 一次排队（服务端逐个提交，单次最多 50 条；绕过普通 admission，由线程池排队），省去逐条 subagent；不要并发调用多个 batch。
+- `kind=multi`：用户只要一集 → 直接用对应那条 `entries[].url`。要全出 → **默认**每集 `prepare_note_material`（当前 Agent 写笔记）；仅后备 LLM 才用 `batch_generate_notes`。超过 200 条 `truncated=true`。
+- **批量（仅后备 LLM）**：合集要配置 LLM 全出笔记时用 `batch_generate_notes(url, max_entries=10)` 一次排队（服务端逐个提交，单次最多 50 条；绕过普通 admission，由线程池排队）；不要并发调用多个 batch。
 - 内置平台之外 `platform:"generic"` 走 yt-dlp 通用提取（覆盖 1800+ 站点）；链接无效（空/本地缺失/内网/解析失败）→ `{ok:false, platform?, error}`。
 
 ### `batch_generate_notes(video_url, max_entries=10, quality?, provider_id?, model_name?, format?, style?, screenshot?, extras?, link?, video_understanding?, video_interval?, grid_size?, include_comments?, comments_limit?, notes_dir?)`
-- **播放列表/合集/分 P 批量提交**：内部先 `inspect_video` 展开，再逐条提交笔记任务（单次最多 50 条；绕过普通 admission，由线程池排队）。高级参数与 `generate_note` 一致（视频理解/弹幕/notes_dir 批量共享同一套设置）；不要并发调用多个 batch，避免队列堆积。
+- **仅后备 LLM**：播放列表/合集/分 P 批量提交配置 LLM 笔记。内部先 `inspect_video` 展开，再逐条 `generate_note`（单次最多 50 条；绕过普通 admission，由线程池排队）。**默认路径不要用它**——每集 `prepare_note_material`，由当前 Agent 写。
 - 返回 `{ok, total, submitted, truncated?, errors:[{p, title, url, error}], tasks:[{p, title, duration, url, task_id, status}]}`；单条失败不阻断其余，inspect 失败也走同一形状（`total:0, submitted:0, errors:[...]`）。
 - 之后逐个 `task(task_id)` 轮询（多任务逐个汇报进度，不要同时并行轮询过多）。
 
@@ -36,7 +37,7 @@
   - **MCP Resource `videonote://task/{task_id}/transcript`**：转写全文按时间轴渲染的纯文本（含说话人标签），适合整篇直读；工具版用于切片/结构化。
 - **`action="cancel"`**：取消进行中/排队任务（协作式，下一阶段边界生效，LLM 总结时每 chunk 检查）；取消事件沿字幕、下载、ASR、预处理、ffmpeg、抽帧、说话人分离、B 站弹幕/评论与后处理传播，可控 ffmpeg/下载子进程会尽快退出，但不能硬中断正在进行的第三方 HTTP。运行中通常先返回 `CANCELLING`，排队任务可直接写 `CANCELLED`。
 
-## AGENT 直接生成（准备素材）
+## 默认路径（准备素材）
 
 ### `prepare_note_material(video_url, platform?, video_understanding?, video_interval?, grid_size?, include_comments?, comments_limit?)`
 - **只准备素材、不调用配置 LLM**：跑下载 → 转写 →（可选）抽帧 →（可选）评论/弹幕，返回素材包（`kind: "material"`）。
@@ -57,7 +58,7 @@
     "audio_path": "/绝对/路径/audio.mp3"
   }
   ```
-- 用途：**AGENT 直接生成**（agent_direct）—— AGENT 自己读转写、用 Read 看 `frames` 图片、按 `comments_danmaku` 写「观众观点」章节，不经配置 LLM。转写文本优先用 `task(task_id, action="transcript", segment_range=...)` 按需取（超长分段，避免撑爆 context）；评论/弹幕默认已在素材包 result 里（`raw` 恒剥）。
+- 用途：**默认路径**——当前对话 Agent 读转写、用 Read 看 `frames` 图片、按 `comments_danmaku` 写「观众观点」章节，不经配置 LLM。转写文本优先用 `task(task_id, action="transcript", segment_range=...)` 按需取（超长分段，避免撑爆 context）；评论/弹幕默认已在素材包 result 里（`raw` 恒剥）。
 
 ## 媒体加工（导出 / 合并 / 说话人分离）
 
@@ -85,11 +86,11 @@
 - 零额外依赖（FFmpeg）；降噪（noisereduce）可选 extras，未装静默降级。
 - **时长探测区别**：VideoReader 的视频 ffprobe 有 120 秒硬超时，并拒绝无法解析、NaN、Inf、负数；`audio_preprocess.probe_duration` 是 best-effort，失败返回 0，`chunk_duration_guess` 会回退 1800 秒并 warning。
 
-## 全自动 / 手动模式
+## 默认 / 手动 / 后备 LLM
 
-- **默认全自动**：不要先问模式；`generate_note` 不传可选参数即套 setup / userConfig。不要主动问后续优化。
-- **手动**：仅当用户说「手动 / 我要选参数」时逐项问（模型、风格、视频理解、评论、截图）。
-- **AGENT 直接生成**：仅当用户明确要「你自己写」/`agent_direct`。`agent_direct` 配置键 server 不读，只是编排选择。
+- **默认**：当前对话 Agent 写笔记。`health_check(need_provider=False)` → `prepare_note_material` → 读转写/帧 → 你写。不要先问模式，不要主动问后续优化。
+- **手动**：仅当用户说「手动 / 我要选参数」时逐项问（风格、视频理解、评论、截图；后备路径再问模型）。
+- **后备 LLM**：仅当你无法看图，或用户明确要配置 LLM。`health_check(need_provider=True)` → `generate_note` / 合集 `batch_generate_notes`。`agent_direct` 配置键 server 不读；不要因为该键是 false 就改走后备。
 
 ## 任务索引与清理
 
@@ -134,11 +135,11 @@
 
 ## 体检（提交前）
 
-### `health_check(need_provider=true, provider_id?, url?, platform?)`
+### `health_check(need_provider=false, provider_id?, url?, platform?)`
 - 体检（#138）：检查 MCP 运行环境与提交前就绪状态，`checks` 数组逐项给出 `{name, ok, detail}`。
 - 检查项：ffmpeg / 数据库 / 磁盘剩余 / 转写器就绪（本地模型已下载/云端 key）/ 供应商 key 与模型（仅 `need_provider=True`）/ 任务队列；`url` 非空时顺带预解析视频时长（仅参考，不拦截），返回额外 `duration_secs`。
 - 返回 `{ok, server_version, plugin_version, whisper_models, engine_advice, audio_enhance, keyed_providers, queue_length, max_workers, data_dir, skill_refresh, checks, duration_secs?}`。`ok=false` 时先解决 `detail` 里的问题再提交，避免长任务跑到半路才因模型未下载 / 磁盘满失败。
-- **`need_provider` 默认 True**（generate_note 需要 LLM 供应商）。只做素材包（prepare_note_material 不调 LLM）时传 False，跳过供应商 key/模型检查——否则会得到「无已填 key 的供应商」的误导结论（#124 A12）。
+- **`need_provider` 默认 False**（#151：默认路径 Agent 写笔记，不需要供应商）。走 `generate_note` / `batch_generate_notes` 后备时传 True，才检查供应商 key/模型。
 
 ## 配置要点
 
@@ -153,13 +154,13 @@
 | B 站登录/AI 字幕/评论 | 用户在本会话 `! videonote login bilibili` 扫码（二维码渲染进会话终端，存 SESSDATA） |
 | 小宇宙官方文稿 | 用户在本会话 `! videonote login xiaoyuzhou` 用小宇宙 App 扫码（或 `--token` 粘贴）；未登录会回退本地下载+ASR，长节目会非常慢 |
 | 小红书视频笔记 | 用户在本会话 `! videonote login xiaohongshu` 用小红书 App 扫码（或 `--cookie` 粘贴）；图文笔记无法转写；无官方字幕，走转写引擎 |
-| 本地文件 | `generate_note(video_url="file:///绝对/路径/foo%20bar.mp4")` 或普通路径，`platform` 可省略 |
+| 本地文件 | `prepare_note_material(video_url="file:///绝对/路径/foo%20bar.mp4")` 或普通路径，`platform` 可省略；后备 LLM 用 `generate_note` |
 | 视频理解默认（setup ③） | 用户说「用默认」/ 全自动模式时不传 `video_understanding`/`video_interval` 即套用（默认关/6s） |
 | 评论/弹幕整合默认（setup ③） | 用户说「用默认」/ 全自动模式时不传 `include_comments`/`comments_limit` 即套用（默认关/20 条） |
-| 笔记默认（setup ③ 新增） | `default_style`（默认 detailed）/ `default_screenshot`（默认关）/ `agent_direct`（默认关，行为与之前一致）；全自动模式不传即套用 |
+| 笔记默认（setup ③） | `default_style`（默认 detailed）/ `default_screenshot`（默认关）/ `agent_direct`（Skill 默认 Agent 写笔记，server 不读此键；旧向导曾默认关，忽略 false） |
 | 导出格式默认（setup ③ 新增） | `default_export_formats`（srt/vtt/json，默认空）；任务成功后自动导出这些格式，`process_media(action="export")` 不传 formats 时也套用它 |
 | 音频预处理（setup ②） | `transcriber preprocess on/off` 或 setup ② 勾选；16kHz 归一 + 超长分块（默认关，零依赖） |
 | 说话人分离（setup ②） | `transcriber diarization on/off` 或 setup ② 勾选；pyannote 可选重依赖 + HF_TOKEN + 模型授权 |
 | 切中文转写（funasr） | `! videonote transcriber set funasr`；需 `uvx --with funasr --with torch`（重依赖可选），模型自动下载 |
 | 其他平台（非内置平台） | `inspect_video` 返回 `platform:"generic"` → 自动走 yt-dlp 通用提取（覆盖 1800+ 站点） |
-| AGENT 直接生成 | `prepare_note_material(video_url, ...)` → 轮询 SUCCESS → 读素材包 → **AGENT 自己写笔记**（不调用配置 LLM） |
+| 默认路径（当前 Agent 写） | `prepare_note_material(video_url, ...)` → 轮询 SUCCESS → 读素材包 → **当前 Agent 自己写笔记**（不调用配置 LLM） |

--- a/skills/videonote/reference/troubleshooting.md
+++ b/skills/videonote/reference/troubleshooting.md
@@ -26,15 +26,15 @@
 | 任务完成阶段报数据库/索引写入失败 | DAO 会 rollback 后重新抛出；`_save_metadata` 不再吞掉 `video_tasks` 插入失败，因此任务不会伪装成 SUCCESS。检查 SQLite 权限/锁与日志后重试 |
 | 转写输出异常（开预处理后） | 预处理默认关；若开了又出问题，`! videonote transcriber preprocess off` 关闭对比 |
 | 视频下载 403 / 需会员 | 让用户 `videonote setup` 向导里配「平台 Cookie」（MCP 工具不收 cookie，见安全红线） |
-| `generate_note` 报「已有 N 个进行中任务（上限 M）」 | 普通任务 admission 已达上限 —— 提交时已预占名额，覆盖排队与执行全生命周期；等其中一些完成（或 `task(task_id, action="cancel")` 取消）再提交。合集/多集用 `batch_generate_notes`（单次最多 50 条，绕过普通 admission，由线程池排队），不要并发调用多个 batch；互相独立的链接用 subagent 并行 |
+| `generate_note` 报「已有 N 个进行中任务（上限 M）」 | 普通任务 admission 已达上限 —— 提交时已预占名额，覆盖排队与执行全生命周期；等其中一些完成（或 `task(task_id, action="cancel")` 取消）再提交。默认路径合集逐条 `prepare_note_material`（先提交最多 3 个）；后备 LLM 的合集用 `batch_generate_notes`（单次最多 50 条，绕过普通 admission）；互相独立的链接用 subagent |
 | `task(action="cancel")` 后仍显示 `CANCELLING` | 这是协作式取消：事件会在字幕、下载、ASR、预处理、ffmpeg、抽帧、说话人分离、B 站弹幕/评论和后处理检查点传播；可控 ffmpeg/下载子进程会尽快退出，但正在进行的 HTTP/模型推理不能硬中断 |
 | 想取消 `process_media` | `process_media` 是同步工具，不登记任务注册表，没有可供 `task(action="cancel")` 控制的后台 task_id；只能等待当前 export/merge/diarize 调用自然返回 |
 
 ## 并发与多会话
 
 - 每个会话独立起一个 MCP server 进程，任务按 `task_id` 隔离 —— **多个会话可并行生成不同视频的笔记**。
-- **普通任务 admission**：本会话内 `generate_note` / `prepare_note_material` 受 `VIDEONOTE_MAX_WORKERS`（默认 3）限制，超出上限会**拒绝**（防止无界排队）。**合集 / 分 P / 播放列表**：一条 `batch_generate_notes` 单次最多 50 条，绕过普通 admission，由线程池逐个排队；不要并发调用多个 batch。**互相独立的多个链接**：每个 url 一个 **subagent**（generate_note → `task(task_id)` 轮询 → 汇报），主 agent 汇总。**主 agent 自己不要在同一回合连续调用多个 `generate_note`**。
-- **真正并行**：开多个会话。
+- **普通任务 admission**：本会话内 `generate_note` / `prepare_note_material` 受 `VIDEONOTE_MAX_WORKERS`（默认 3）限制，超出上限会**拒绝**（防止无界排队）。**默认路径**：合集/分 P 每集 `prepare_note_material`（先提交最多 3 个，完成再下一批）；互相独立的链接各一个 **subagent**（提交 → 轮询 → 读素材 → 写笔记 → 汇报）。**后备 LLM**：合集一条 `batch_generate_notes`（单次最多 50 条，绕过普通 admission，由线程池排队）；不要并发调用多个 batch。**主 agent 自己不要在同一回合并行多个 `generate_note` / `prepare_note_material`**。
+- **真正突破会话上限**：开多个会话。
 - **轮询**：用轻量 `task(task_id)`（默认 action="status"）快照轮询。
 - 提交前把计划告诉用户（如「我会依次提交 p10/p11/p12，每个完成后提交下一个」）。
 - 资源：whisper/MLX 转写吃 CPU/内存，太多会话并行会卡顿；所有会话共用同一 SQLite，极端并发偶发写冲突。

--- a/tests/test_138_batch.py
+++ b/tests/test_138_batch.py
@@ -6,8 +6,8 @@
    全局 dry_run 预览形状保留；
 3. process_media 三分支必填参数校验（export 缺 task_id / merge 缺 files / diarize 缺
    audio_file），hf_token 蜜罐与 action 无关（防切换分支绕过凭证红线）；
-4. health_check 统一形状：ok/checks 恒在（db 检查项并入），need_provider=False 跳过
-   provider 检查。
+4. health_check 统一形状：ok/checks 恒在（db 检查项并入），need_provider 默认 False（#151），
+   显式 True 才查供应商。
 """
 import json
 import sys

--- a/tests/test_151_batch.py
+++ b/tests/test_151_batch.py
@@ -1,0 +1,88 @@
+"""#151 Skill 默认由当前 Agent 写笔记：非多模态才走配置 LLM。
+
+契约：
+1. SKILL.md 把 prepare_note_material 当默认、generate_note/batch 当后备；
+2. health_check 默认 need_provider=False；合集预解析提示默认 prepare 而非 batch；
+3. inspect_video / generate_note / batch_generate_notes docstring 口径与 SKILL 一致。
+"""
+from __future__ import annotations
+
+import inspect
+import json
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from videonote_mcp import server
+
+_REPO = Path(__file__).resolve().parent.parent
+_SKILL = (_REPO / "skills" / "videonote" / "SKILL.md").read_text(encoding="utf-8")
+
+
+class SkillDefaultAgentWriterTest(unittest.TestCase):
+    def test_skill_default_path_is_prepare_not_generate(self):
+        self.assertIn("prepare_note_material", _SKILL)
+        self.assertIn("health_check(need_provider=False)", _SKILL)
+        self.assertIn("后备路径", _SKILL)
+        # 默认路径禁止把合集交给 batch
+        self.assertIn("不要**对默认路径用 `batch_generate_notes`", _SKILL)
+        # 判定条款：不能看图才走配置 LLM
+        self.assertIn("纯文本模型", _SKILL)
+        self.assertIn("后备 LLM", _SKILL)
+
+    def test_skill_does_not_treat_agent_direct_false_as_generate(self):
+        self.assertIn("不要**因为该键是 false 就改走 `generate_note`", _SKILL)
+
+
+class HealthCheckDefaultNeedProviderTest(unittest.TestCase):
+    def test_signature_defaults_false(self):
+        params = inspect.signature(server.health_check).parameters
+        self.assertIs(params["need_provider"].default, False)
+
+    def test_multi_duration_hint_prefers_prepare(self):
+        info = {
+            "ok": True,
+            "kind": "multi",
+            "total": 12,
+            "entries": [{"duration": 60, "url": "https://example.com/p1"}],
+        }
+        with mock.patch.object(server.shutil, "which", return_value="/usr/bin/ffmpeg"):
+            with mock.patch.object(
+                server.shutil, "disk_usage", return_value=mock.Mock(free=10 * 1024**3)
+            ):
+                with mock.patch.object(
+                    server.TranscriberConfigManager,
+                    "is_model_ready",
+                    return_value={
+                        "ready": True,
+                        "transcriber_type": "fast-whisper",
+                        "model_size": "small",
+                        "downloading": False,
+                        "reason": "",
+                    },
+                ):
+                    with mock.patch(
+                        "app.services.inspect.inspect_video", return_value=info
+                    ):
+                        data = json.loads(server.health_check(url="https://example.com/list"))
+        detail = {c["name"]: c for c in data["checks"]}["duration"]["detail"]
+        self.assertIn("prepare_note_material", detail)
+        self.assertIn("batch_generate_notes", detail)
+        self.assertIn("后备", detail)
+
+
+class ToolDocstringRoutingTest(unittest.TestCase):
+    def test_inspect_video_docstring_default_prepare(self):
+        doc = server.inspect_video.__doc__ or ""
+        self.assertIn("prepare_note_material", doc)
+        self.assertIn("后备", doc)
+
+    def test_generate_note_docstring_is_fallback(self):
+        doc = server.generate_note.__doc__ or ""
+        self.assertIn("后备", doc)
+        self.assertIn("prepare_note_material", doc)
+
+    def test_batch_generate_notes_docstring_is_fallback(self):
+        doc = server.batch_generate_notes.__doc__ or ""
+        self.assertIn("后备", doc)
+        self.assertIn("prepare_note_material", doc)

--- a/tests/test_server_contracts.py
+++ b/tests/test_server_contracts.py
@@ -404,10 +404,20 @@ class PreflightNeedProviderTest(unittest.TestCase):
             },
         )
 
-    def test_default_includes_provider_check(self):
-        with mock.patch.object(server, "_preflight_provider", return_value=(False, "无已填 key 的供应商")) as m_p:
+    def test_default_skips_provider_check(self):
+        """#151：health_check 默认 need_provider=False（Agent 写笔记不需要供应商）。"""
+        with mock.patch.object(server, "_preflight_provider") as m_p:
             with self._mock_base_checks()[0], self._mock_base_checks()[1], self._mock_base_checks()[2]:
                 data = json.loads(server.health_check())
+        m_p.assert_not_called()
+        names = {c["name"] for c in data["checks"]}
+        self.assertNotIn("provider", names)
+        self.assertTrue(data["ok"])
+
+    def test_need_provider_true_includes_provider_check(self):
+        with mock.patch.object(server, "_preflight_provider", return_value=(False, "无已填 key 的供应商")) as m_p:
+            with self._mock_base_checks()[0], self._mock_base_checks()[1], self._mock_base_checks()[2]:
+                data = json.loads(server.health_check(need_provider=True))
         m_p.assert_called_once()
         names = {c["name"] for c in data["checks"]}
         self.assertIn("provider", names)
@@ -445,7 +455,7 @@ class PreflightTest(unittest.TestCase):
                     server.TranscriberConfigManager, "is_model_ready", return_value=self._ready()
                 ):
                     with mock.patch.object(server, "_preflight_provider", return_value=(True, "openai（key 已填，默认模型 gpt-4o）")):
-                        data = json.loads(server.health_check())
+                        data = json.loads(server.health_check(need_provider=True))
         self.assertTrue(data["ok"])
         by_name = {c["name"]: c for c in data["checks"]}
         self.assertTrue(by_name["ffmpeg"]["ok"])

--- a/uv.lock
+++ b/uv.lock
@@ -4058,7 +4058,7 @@ wheels = [
 
 [[package]]
 name = "videonote"
-version = "0.1.24"
+version = "0.1.25"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.24"
+__version__ = "0.1.25"

--- a/videonote_mcp/cli.py
+++ b/videonote_mcp/cli.py
@@ -645,7 +645,7 @@ def _wizard_other(inq) -> None:
             cm_lim = resolve_int_config("comments_limit", "VIDEONOTE_COMMENTS_LIMIT", 20)
             st_style = get_app_config().get("default_style") or "detailed"
             ss_on = bool(get_app_config().get("default_screenshot", False))
-            ad_on = bool(get_app_config().get("agent_direct", False))
+            ad_on = True if get_app_config().get("agent_direct") is None else bool(get_app_config().get("agent_direct"))
             _show_header("③ 其他设置")
             pick = inq.select(
                 message="选择要配置的项（← 返回）",
@@ -767,9 +767,10 @@ def _wizard_other(inq) -> None:
                     keybindings=_KB,
                 ).execute()
                 set_app_config("default_screenshot", bool(ss))
+                _ad_cur = get_app_config().get("agent_direct")
                 ad = inq.confirm(
-                    message="默认用 AGENT 直接写笔记（不走配置 LLM）？",
-                    default=bool(get_app_config().get("agent_direct", False)),
+                    message="笔记由当前对话 Agent 写（推荐；仅当 Agent 无法看图才走配置 LLM）？",
+                    default=True if _ad_cur is None else bool(_ad_cur),
                     keybindings=_KB,
                 ).execute()
                 set_app_config("agent_direct", bool(ad))
@@ -1182,7 +1183,11 @@ def _setup_cli_fallback() -> None:
     cur_ss = bool(get_app_config().get("default_screenshot", False))
     ss = _ask(f"   默认开启截图？[y/N]（当前 {'开' if cur_ss else '关'}）", default="Y" if cur_ss else "N").lower() == "y"
     set_app_config("default_screenshot", bool(ss))
-    ad = _ask("   默认用 AGENT 直接写笔记（不走配置 LLM）？[y/N]", default="N").lower() == "y"
+    _ad_cur = get_app_config().get("agent_direct")
+    ad = _ask(
+        "   笔记由当前对话 Agent 写（仅当 Agent 无法看图才走配置 LLM）？[Y/n]",
+        default="Y" if _ad_cur is None or bool(_ad_cur) else "N",
+    ).lower() == "y"
     set_app_config("agent_direct", bool(ad))
     print(f"   ✓ 笔记默认：风格 {style} / 截图 {'开' if ss else '关'} / AGENT直接写 {'开' if ad else '关'}", file=sys.stdout)
     print("   导出格式默认：任务成功后自动把转写导出为纯格式（确定性渲染，不耗 LLM）", file=sys.stdout)

--- a/videonote_mcp/server.py
+++ b/videonote_mcp/server.py
@@ -947,7 +947,10 @@ def generate_note(
     include_comments: Optional[bool] = None,
     comments_limit: Optional[int] = None,
 ) -> str:
-    """提交一个视频链接/本地文件，异步生成 AI Markdown 笔记。
+    """提交一个视频链接/本地文件，用配置 LLM 异步生成 AI Markdown 笔记。
+
+    后备路径：当前对话 Agent 无法看图，或用户明确要求配置 LLM 时才用。
+    默认路径是 prepare_note_material，由 Agent 自己写笔记。
 
     - video_url: 必填，B 站/YouTube/抖音/快手/小宇宙/小红书链接或本地文件路径；
     - platform: 可省略，自动识别；
@@ -971,8 +974,6 @@ def generate_note(
 
     返回 {task_id, status, platform}。之后用 task(task_id) 轮询。SUCCESS 时 result.note_dir 指向 note.md 所在目录（{task_id}/gen/，
     指定 notes_dir 时另有 result.portable_note_dir 指向便携副本）。
-
-    只需素材（转写/帧/评论，不调 LLM 总结）供自行写笔记时，用 prepare_note_material。
     """
     # 先做平台检测/handoff/本地校验——handoff 和「本地文件不存在」不需要 provider
     # （docs 审计 H 组：此前 provider 解析在前，unsupported 链接也会先撞 provider 报错）
@@ -1135,7 +1136,7 @@ def prepare_note_material(
     之后用 task(task_id) 轮询；SUCCESS 时 result 含
     {kind: material, title, transcript, frames, comments_danmaku, video_path, audio_path}。
     transcript 优先来自平台官方字幕（YouTube/B 站人工+自动字幕、小宇宙官方文稿），无字幕才走转写引擎。
-    需要 AI 生成结构化 Markdown 笔记请用 generate_note。
+    这是默认路径（当前对话 Agent 写笔记）。配置 LLM 后备请用 generate_note。
     """
     if platform is None:
         platform = _detect_platform(video_url)
@@ -1780,7 +1781,7 @@ def _installed_plugin_version() -> Optional[str]:
 
 @mcp.tool()
 def health_check(
-    need_provider: bool = True,
+    need_provider: bool = False,
     provider_id: Optional[str] = None,
     url: str = "",
     platform: Optional[str] = None,
@@ -1796,9 +1797,8 @@ def health_check(
     checks: [{name, ok, detail}], duration_secs?}。ok=false 时先解决 detail 里的问题
     再提交，避免长任务跑到半路才因模型未下载 / 磁盘满失败。
 
-    - need_provider: 默认为 True（generate_note 需要 LLM 供应商）。
-      只做素材包（prepare_note_material 不调 LLM）时传 False，跳过供应商检查——
-      否则会得到「无已填 key 的供应商」的误导结论（#124 A12）。
+    - need_provider: 默认 False（#151：默认路径是 Agent 写笔记，不需要配置 LLM）。
+      走 generate_note / batch_generate_notes 后备时传 True，才检查供应商 key/模型。
     """
     checks: List[Dict[str, Any]] = []
 
@@ -1898,7 +1898,7 @@ def health_check(
                         {
                             "name": "duration",
                             "ok": True,
-                            "detail": f"多集共 {info.get('total', len(entries))} 条（多集全出建议一条 batch_generate_notes 服务端逐个排队；只一集用对应 entries[].url）",
+                            "detail": f"多集共 {info.get('total', len(entries))} 条（默认每集 prepare_note_material 由当前 Agent 写；后备 LLM 才用 batch_generate_notes；只要一集用对应 entries[].url）",
                         }
                     )
                 else:
@@ -2062,9 +2062,10 @@ def inspect_video(url: str, platform: Optional[str] = None) -> str:
 
     单视频 {ok, platform, kind: single, title, video_id, total, entries}；
     多集（B 站分 P / YouTube 播放列表）kind: multi，entries[].url 可直接喂给
-    `generate_note` / `prepare_note_material`；一个链接内的多集（分 P/播放列表）
-    用一条 `batch_generate_notes` 全出笔记（#125 C4，与 #110 batch 口径一致）；
-    互相独立的链接才各自开 subagent。
+    `prepare_note_material`（默认：当前 Agent 写笔记）或 `generate_note`（后备 LLM）。
+    只要一集 → 用对应 `entries[].url`。要全出：默认每集 `prepare_note_material`；
+    仅当当前 Agent 无法看图或用户要求配置 LLM 时才一条 `batch_generate_notes`。
+    互相独立的链接各开 subagent。
 
     返回 {ok, platform, kind: single|multi, title, video_id, current_p?,
     total, truncated, entries:[{p, title, duration, url, video_id}]}。
@@ -2171,7 +2172,10 @@ def batch_generate_notes(
     comments_limit: Optional[int] = None,
     notes_dir: Optional[str] = None,
 ) -> str:
-    """对播放列表/合集/分 P 链接批量提交笔记任务（服务端逐个排队）。
+    """对播放列表/合集/分 P 链接批量提交「配置 LLM」笔记任务（服务端逐个排队）。
+
+    这是后备路径：当前对话 Agent 无法看图，或用户明确要求配置 LLM 时才用。
+    默认路径是每集 `prepare_note_material`，由 Agent 自己写笔记。
 
     参数策略：除 video_url 外全部可选——不传即套 setup ③ 配置的默认
     （与 generate_note 同款；仅需覆盖时显式传）。每条任务同样优先用平台官方字幕
@@ -2185,8 +2189,9 @@ def batch_generate_notes(
       generate_note 任务。
 
     内部先 inspect_video 展开条目再逐条提交（单次最多 50 条；batch 显式绕过普通
-    admission，由线程池负责排队；不要并发调用多个 batch）。与 SKILL「多集用 subagent
-    逐个提交」纪律不同——本工具把展开+排队收敛到服务端）。
+    admission，由线程池负责排队；不要并发调用多个 batch）。与默认路径「每集
+    prepare_note_material、Agent 自己写」不同——本工具把配置 LLM 的展开+排队
+    收敛到服务端。
     返回 {ok, total, submitted, truncated?, errors:[{p, title, url, error}],
     tasks:[{p, title, duration, url, task_id, status}]}。
     单条失败不阻断其余；全部失败时 ok=false。之后逐个 task(task_id) 轮询。


### PR DESCRIPTION
## Summary
- 自 v0.1.24 起合入 #151：默认由当前对话 Agent 写笔记（`prepare_note_material`）；仅当 Agent 无法看图或用户明确要求时才走配置 LLM（`generate_note` / `batch_generate_notes`）。`health_check.need_provider` 默认改为 False。
- 测试基线 973 → **981 passed, 1 skipped, 10 subtests**；Ruff F/I 干净。
- 四处版本对齐到 **0.1.25**（`pyproject.toml` / `__init__.py` / `plugin.json` / `uv.lock`）。合并后打 **新标签** `v0.1.25`，触发 `release.yml` → GitHub Release + PyPI Trusted Publishing。
- Skill 行为变更：合并后需 `claude plugin disable videonote@videonote` 再 `install` 才拿到新 SKILL。MCP 走 `uvx videonote@latest` 会在发版后自动取 0.1.25。

## Test plan
- [x] 本机全量 `981 passed, 1 skipped, 10 subtests` + ruff F/I-clean + `git diff --check`
- [x] 四处版本字符串均为 `0.1.25`
- [ ] CI Smoke test 绿（Python 3.11/3.12/3.13）
- [ ] 合并后打 `v0.1.25` tag，确认 release.yml：四处版本一致 + 测试门禁 + wheel 内容 + MCP handshake + PyPI 发布
- [ ] 发布后 `uvx videonote@0.1.25` 能启动，`health_check` 的 `server_version` 为 `0.1.25`
- [ ] 合并后 `origin/dev` **快进**到 `origin/main`（不要再开同步 merge commit）


Made with [Cursor](https://cursor.com)