### PR TITLE
release: v0.1.26（抖音 SSO 扫码登录）

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/Xiaoyuzhou/Xiaohongshu/local)",
   "author": {
     "name": "HuangYincan",

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ claude plugin install videonote@videonote
 #    装完在会话里跑配置向导收尾：
 /videonote-setup
 
-# 3) （可选）后备 LLM 的 Key / B 站扫码 / CLI 向导——默认路径不需要配置 LLM
+# 3) （可选）后备 LLM 的 Key / 平台扫码（B 站、抖音等） / CLI 向导——默认路径不需要配置 LLM
 # ! videonote setup
 
 # 4) 重启会话，对 agent 说「帮我给这个视频做笔记」+ 链接

--- a/README_EN.md
+++ b/README_EN.md
@@ -42,7 +42,7 @@ claude plugin install videonote@videonote
 #    video-understanding / comments etc.); then run the guided config command:
 /videonote-setup
 
-# 3) (Optional) fallback LLM key / Bilibili QR login / CLI wizard — default path needs no LLM key
+# 3) (Optional) fallback LLM key / platform QR login (Bilibili, Douyin, …) / CLI wizard — default path needs no LLM key
 # ! videonote setup
 
 # 4) Restart your session, tell the agent "make notes for this video" + link

--- a/VENDOR.md
+++ b/VENDOR.md
@@ -13,7 +13,7 @@
 
 | 子包 | 内容 |
 |------|------|
-| `app/downloaders/` | base, common, bilibili_downloader, bilibili_dm_patch, bilibili_subtitle, **bilibili_comment**, youtube_downloader, youtube_subtitle, douyin_downloader, kuaishou_downloader, local_downloader, **generic_downloader**, **xiaoyuzhou_downloader**, **xiaoyuzhou_subtitle**, **xiaohongshu_downloader**, **xiaohongshu_auth**, **xiaohongshu_sign**, **xiaohongshu_browser** + 子包 `douyin_helper/`、`kuaishou_helper/`（旧 stub `xiaoyuzhoufm_download` 已删除 2026-08-17；2026-08-30 重新接入为一等平台 + 官方文稿；2026-08-31 小红书一等平台 + 扫码登录；同日扫码改为本机 Chrome 跑官网 JS，因 edith 拒旧 x-s 406） |
+| `app/downloaders/` | base, common, bilibili_downloader, bilibili_dm_patch, bilibili_subtitle, **bilibili_comment**, youtube_downloader, youtube_subtitle, douyin_downloader, **douyin_auth**, kuaishou_downloader, local_downloader, **generic_downloader**, **xiaoyuzhou_downloader**, **xiaoyuzhou_subtitle**, **xiaohongshu_downloader**, **xiaohongshu_auth**, **xiaohongshu_sign**, **xiaohongshu_browser** + 子包 `douyin_helper/`、`kuaishou_helper/`（旧 stub `xiaoyuzhoufm_download` 已删除 2026-08-17；2026-08-30 重新接入为一等平台 + 官方文稿；2026-08-31 小红书一等平台 + 扫码登录；同日扫码改为本机 Chrome 跑官网 JS，因 edith 拒旧 x-s 406；2026-09-09 抖音扫码登录 `sso.douyin.com` get_qrcode + check_qrconnect） |
 | `app/transcriber/` | base, transcriber_provider, whisper, groq, bcut, kuaishou, mlx_whisper_transcriber, **funasr_transcriber**, **audio_preprocess**, model_download_state, whisper_models |
 | `app/gpt/` | base, gpt_factory, universal_gpt, prompt, prompt_builder, request_chunker + `app/gpt/provider/OpenAI_compatible_provider.py`（gpt_factory 依赖）（openai_gpt / deepseek_gpt / qwen_gpt / utils / tools **已删除** 2026-08-17：全仓零引用——gpt_factory 走 OpenAICompatibleProvider 直连，上游直连类死代码） |
 | `app/db/` | engine, init_db, provider_dao, model_dao, video_task_dao + `app/db/models/`（models, providers, video_tasks）（sqlite_client **已删除** 2026-08-17：全仓零引用 + CWD 相对 DB 路径死引信） |
@@ -58,7 +58,7 @@
 - `app/gpt/universal_gpt.py`（checkpoint 损坏弃用时打 warning 留痕，#106）
 - `app/downloaders/xiaohongshu_downloader.py` / `xiaohongshu_auth.py` / `xiaohongshu_browser.py` / `xiaoyuzhou_subtitle.py`（2026-09-01 #144：笔记页 host 钉死、cookie 域精确后缀、Playwright 响应/二维码官方域、官方文稿失败不回退 ASR；2026-09-01 #145：下载器 close 自建 Auth/Session；上游同步需人工合并）
 - `app/downloaders/douyin_downloader.py` / `kuaishou_helper/kuaishou.py` / `app/transcriber/bcut.py` / `app/downloaders/youtube_subtitle.py`（2026-09-01 #145：裸 requests 改 PublicOnlySession/public_get/post；必剪上传 URL 入口校验；YouTube 字幕 Session 默认超时）
-- 整文件为本仓库新增：`pipeline.py`、`merge.py`、`diarization.py`、`inspect.py`、`note_cache.py`、`audio_preprocess.py`、`funasr_transcriber.py`、`generic_downloader.py`、`bilibili_comment.py`、`xiaoyuzhou_downloader.py`、`xiaoyuzhou_subtitle.py`、`xiaohongshu_downloader.py`、`xiaohongshu_auth.py`、`xiaohongshu_sign.py`、`xiaohongshu_browser.py`、`task_manifest.py`、`json_store.py`、`url_safety.py`（2026-09-01 #147：`pin_public_host` / 连接期 DNS 钉死）
+- 整文件为本仓库新增：`pipeline.py`、`merge.py`、`diarization.py`、`inspect.py`、`note_cache.py`、`audio_preprocess.py`、`funasr_transcriber.py`、`generic_downloader.py`、`bilibili_comment.py`、`xiaoyuzhou_downloader.py`、`xiaoyuzhou_subtitle.py`、`xiaohongshu_downloader.py`、`xiaohongshu_auth.py`、`xiaohongshu_sign.py`、`xiaohongshu_browser.py`、`douyin_auth.py`、`task_manifest.py`、`json_store.py`、`url_safety.py`（2026-09-01 #147：`pin_public_host` / 连接期 DNS 钉死；2026-09-09 抖音 SSO 扫码）
 
 ## 本轮审查新增语义分叉（2026-09-01 #148）
 

--- a/app/downloaders/douyin_auth.py
+++ b/app/downloaders/douyin_auth.py
@@ -1,0 +1,272 @@
+"""抖音 Web 扫码登录。
+
+走官网 SSO：`sso.douyin.com/get_qrcode/` + `/check_qrconnect/`，确认后跟随
+官方 `redirect_url` 收集 Cookie，写入 CookieConfigManager 的 `douyin` 槽。
+
+凭证走 CLI：`videonote login douyin` / `videonote cookie set douyin`。
+MCP 工具不收 cookie（安全红线）。
+"""
+from __future__ import annotations
+
+import random
+import re
+import string
+from typing import Optional
+from urllib.parse import urlparse
+
+from app.services.cookie_manager import CookieConfigManager
+from app.utils.logger import get_logger
+from app.utils.url_safety import PublicOnlySession, host_matches, sanitize_error_text
+
+logger = get_logger(__name__)
+
+SSO = "https://sso.douyin.com"
+HOME = "https://www.douyin.com"
+ACCOUNT_INFO = "https://www.douyin.com/passport/web/account/info/"
+_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+_WEB_HEADERS = {
+    "User-Agent": _UA,
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+    "Origin": HOME,
+    "Referer": f"{SSO}/",
+}
+
+# 扫码状态（SSO data.status）：1 等待 / 2 已扫待确认 / 3 成功 / 5 过期
+QR_WAIT = "1"
+QR_SCANNED = "2"
+QR_SUCCESS = "3"
+QR_EXPIRED = "5"
+
+_DOUYIN_HOSTS = ("douyin.com", "snssdk.com")
+
+
+def is_douyin_qr_url(url: str) -> bool:
+    """扫码 payload 只允许抖音 / aweme.snssdk 官方域。"""
+    return host_matches(url, *_DOUYIN_HOSTS)
+
+
+def is_douyin_redirect_url(url: str) -> bool:
+    """登录回调只认官方后缀，拒绝跟随到任意 Location。"""
+    return host_matches(url, *_DOUYIN_HOSTS)
+
+
+def parse_cookie_string(raw: Optional[str]) -> dict:
+    """`a=1; b=2` → dict。空/None → {}。"""
+    out = {}
+    text = (raw or "").strip()
+    if not text:
+        return out
+    for part in re.split(r"[;\n]+", text):
+        part = part.strip()
+        if not part or "=" not in part:
+            continue
+        key, _, value = part.partition("=")
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key:
+            out[key] = value
+    return out
+
+
+def format_cookie(cookies: dict) -> str:
+    return "; ".join(f"{k}={v}" for k, v in cookies.items() if v)
+
+
+def has_sessionid(cookies: dict) -> bool:
+    return bool(cookies.get("sessionid") or cookies.get("sessionid_ss"))
+
+
+def gen_verify_fp() -> str:
+    """生成 s_v_web_id / verifyFp（SSO 多个接口会带）。"""
+    chars = string.ascii_letters + string.digits
+    chunks = ["".join(random.choices(chars, k=n)) for n in (8, 8, 4, 4, 4, 12)]
+    return "verify_" + "_".join(chunks)
+
+
+def _cookie_dict_from_jar(jar) -> dict:
+    try:
+        return {c.name: c.value for c in jar}
+    except Exception:  # noqa: BLE001
+        try:
+            return dict(jar)
+        except Exception:  # noqa: BLE001
+            return {}
+
+
+def _map_qr_status(data: dict) -> str:
+    """把 SSO data.status / redirect_url 归一成 QR_* 常量。"""
+    redirect = (data.get("redirect_url") or "") if isinstance(data, dict) else ""
+    raw = ""
+    if isinstance(data, dict):
+        raw = str(data.get("status", "") or "")
+    if redirect or raw in ("3", "4"):
+        return QR_SUCCESS
+    if raw == "2":
+        return QR_SCANNED
+    if raw == "5":
+        return QR_EXPIRED
+    return QR_WAIT
+
+
+class DouyinAuth:
+    """扫码登录会话。session 可注入（测试 mock）。"""
+
+    def __init__(self, session=None, cookie_mgr: Optional[CookieConfigManager] = None):
+        self._cookie_mgr = cookie_mgr or CookieConfigManager()
+        self._session = session
+        self._owns_session = session is None
+        self.verify_fp = gen_verify_fp()
+
+    def _session_obj(self):
+        if self._session is None:
+            self._session = PublicOnlySession()
+            self._owns_session = True
+        self._session.headers.update(_WEB_HEADERS)
+        try:
+            self._session.cookies.set("s_v_web_id", self.verify_fp, domain=".douyin.com")
+        except Exception:  # noqa: BLE001
+            self._session.cookies.set("s_v_web_id", self.verify_fp)
+        return self._session
+
+    def close(self) -> None:
+        if self._owns_session and self._session is not None:
+            close = getattr(self._session, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:  # noqa: BLE001
+                    pass
+        self._session = None
+
+    def _params(self) -> dict:
+        return {
+            "service": HOME,
+            "need_logo": "false",
+            "need_short_url": "true",
+            "aid": "6383",
+            "account_sdk_source": "sso",
+            "sdk_version": "2.2.7",
+            "language": "zh",
+            "verifyFp": self.verify_fp,
+            "fp": self.verify_fp,
+        }
+
+    def create_qr(self) -> dict:
+        """申请二维码。返回 {token, url}；url 必须是官方域。"""
+        session = self._session_obj()
+        try:
+            session.get(f"{HOME}/", timeout=10)
+        except Exception:  # noqa: BLE001 —— 主站预热失败仍继续出码
+            pass
+        try:
+            resp = session.get(f"{SSO}/get_qrcode/", params=self._params(), timeout=10)
+        except Exception as exc:
+            raise RuntimeError(f"生成二维码失败（网络？）: {sanitize_error_text(exc)}") from exc
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            raise RuntimeError(f"生成二维码失败: HTTP {resp.status_code}") from exc
+        data = payload.get("data") if isinstance(payload, dict) else None
+        if not isinstance(data, dict):
+            data = {}
+        token = data.get("token") or ""
+        qr_url = data.get("qrcode_index_url") or data.get("frontend_show_qrcode") or ""
+        err_code = payload.get("error_code") if isinstance(payload, dict) else None
+        if not token or not qr_url:
+            msg = ""
+            if isinstance(payload, dict):
+                msg = payload.get("description") or payload.get("message") or ""
+            if err_code not in (0, None, "0"):
+                msg = msg or f"error_code={err_code}"
+            raise RuntimeError(f"生成二维码失败: {msg or resp.status_code}")
+        if not is_douyin_qr_url(qr_url):
+            raise RuntimeError("生成二维码失败：返回的二维码地址不是官方域名")
+        return {"token": token, "url": qr_url}
+
+    def poll_qr(self, token: str) -> dict:
+        """轮询扫码状态。返回 {status, redirect_url}。"""
+        if not token:
+            raise RuntimeError("轮询二维码失败：缺少 token")
+        params = self._params()
+        params["token"] = token
+        try:
+            resp = self._session_obj().get(
+                f"{SSO}/check_qrconnect/", params=params, timeout=10
+            )
+        except Exception as exc:
+            raise RuntimeError(f"轮询失败（网络？）: {sanitize_error_text(exc)}") from exc
+        try:
+            payload = resp.json() if resp.content else {}
+        except ValueError:
+            payload = {}
+        data = payload.get("data") if isinstance(payload, dict) else None
+        if not isinstance(data, dict):
+            data = {}
+        return {
+            "status": _map_qr_status(data),
+            "redirect_url": data.get("redirect_url") or "",
+        }
+
+    def finalize(self, redirect_url: str) -> None:
+        """跟随确认后的官方跳转，落地 sessionid 等 Cookie。"""
+        url = (redirect_url or "").strip()
+        if not url:
+            return
+        if not is_douyin_redirect_url(url):
+            host = urlparse(url).netloc or "未知域名"
+            raise ValueError(f"登录回调域名不是抖音官方（{host}）")
+        session = self._session_obj()
+        session.get(url, timeout=10)
+        try:
+            session.get(f"{HOME}/", timeout=10)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def persist(self) -> str:
+        """把当前 session cookie 写入 CookieConfigManager，并探测登录态。"""
+        cookies = _cookie_dict_from_jar(self._session_obj().cookies)
+        raw = format_cookie(cookies)
+        if not has_sessionid(cookies):
+            return "登录成功但未取到 sessionid"
+        self._cookie_mgr.set("douyin", raw)
+        return verify_douyin_login(cookie_mgr=self._cookie_mgr)
+
+
+def verify_douyin_login(cookie_mgr: Optional[CookieConfigManager] = None) -> str:
+    """探测已存登录态。空串=成功，否则是错误信息（不含 cookie 明文）。"""
+    mgr = cookie_mgr or CookieConfigManager()
+    cookies = parse_cookie_string(mgr.get("douyin") or "")
+    if not has_sessionid(cookies):
+        return "未配置 sessionid"
+    try:
+        with PublicOnlySession() as session:
+            session.headers.update(_WEB_HEADERS)
+            for name, value in cookies.items():
+                try:
+                    session.cookies.set(name, value, domain=".douyin.com")
+                except Exception:  # noqa: BLE001
+                    session.cookies.set(name, value)
+            resp = session.get(ACCOUNT_INFO, params={"aid": "6383"}, timeout=15)
+        if resp.status_code in (401, 403):
+            return "登录态无效或已过期，请重新 `videonote login douyin`"
+        if resp.status_code != 200:
+            return f"HTTP {resp.status_code}"
+        try:
+            body = resp.json()
+        except ValueError:
+            body = {}
+        data = body.get("data") if isinstance(body, dict) else None
+        if isinstance(data, dict) and (
+            data.get("user_id") or data.get("uid") or data.get("name") or data.get("uniq_id")
+        ):
+            return ""
+        if isinstance(body, dict) and body.get("message") == "success" and data:
+            return ""
+        return "登录态无效或未能确认，请重新 `videonote login douyin`"
+    except Exception as exc:  # noqa: BLE001
+        logger.info("抖音登录探测失败: %s", sanitize_error_text(exc))
+        return "请求失败（网络？检查 `videonote proxy list`）"

--- a/commands/videonote-setup.md
+++ b/commands/videonote-setup.md
@@ -59,6 +59,7 @@ description: 配置 VideoNote-MCP：体检 / LLM 供应商 / 转写引擎 / 默�
 - **B 站**（AI 字幕 / 评论）：`! videonote login bilibili`。没配 SESSDATA 时仍可转写（走语音识别），只是拿不到 AI 字幕 / 弹幕评论。
 - **小宇宙**（官方文稿）：`! videonote login xiaoyuzhou`。未登录会回退本地下载 + ASR，长节目会很慢。
 - **小红书**（视频笔记）：`! videonote login xiaohongshu`（本机需 Chrome/Edge）。公开视频有时无需登录；遇登录墙 / 验证码时需要。图文笔记无法转写。扫不了可用 `--cookie` 粘贴。
+- **抖音**（视频笔记）：`! videonote login douyin`。公开视频有时无需登录；遇登录墙 / 风控时需要。扫不了可用 `--cookie` 粘贴。
 
 ## 6. 数据管理（可选）
 

--- a/docs/00-新手上路.md
+++ b/docs/00-新手上路.md
@@ -21,7 +21,7 @@ VideoNote-Mcp：把「视频 → AI Markdown 笔记」封装成 MCP server（10 
 | `app/` | **vendored 流水线** + 本仓库分叉：`services/`（note、pipeline、merge、diarization）、`downloaders/`、`transcriber/`、`gpt/`、`db/`（engine + DAO）、`utils/`、`models/`、`enmus/` | 见 `VENDOR.md` 分叉清单——再 sync 上游**不要**当「4 处补丁」重打 |
 | `skills/videonote/` | 用户侧 Skill（SKILL.md + reference/）| 改行为要同步 tools.md |
 | `.claude-plugin/` | marketplace + plugin.json（userConfig env 映射）| 加配置项要同步 plugin.json |
-| `tests/` | #151 全量验证基线为 981 个测试（#150 为 973，#149 为 963，#148 为 948；pytest + unittest 混用，conftest 做隔离）| 新行为必须补测试 |
+| `tests/` | 契约与回归（pytest + unittest 混用，conftest 做隔离）。#151 全量验证基线为 981；抖音扫码登录后为 **1006** | 新行为必须补测试 |
 | `docs/` | 中文文档（本文件 + 索引 + 手册 + 审计史）| 改行为同步 04 手册 |
 | `data/` | 源码 checkout 运行时数据（SQLite、note_results、models、config，gitignored）| 安装模式在 `~/.local/share/videonote-mcp/` |
 
@@ -52,7 +52,7 @@ URL / file:// / 本地路径
 ### 验证三件套（每次改动后跑）
 
 ```bash
-uv run pytest -q            # 全量 981 测试（当前基线）
+uv run pytest -q            # 全量 1006 测试（当前基线）
 uv run ruff check --select F .   # F 类（语法/未定义）——CI 门槛
 uv run ruff check --select I .   # import 排序——CI 门槛
 ```
@@ -71,7 +71,7 @@ uv run ruff check --select I .   # import 排序——CI 门槛
 ### 凭证红线（最高优先级）
 
 **API key / B 站 Cookie / HF token 绝不经 MCP 工具参数或 agent 对话。**
-填 key 走 `! videonote providers set`（对话外用终端）；Cookie 走 `! videonote login bilibili` / `login xiaohongshu` / `setup`。
+填 key 走 `! videonote providers set`（对话外用终端）；Cookie 走 `! videonote login bilibili` / `login xiaohongshu` / `login douyin` / `setup`。
 MCP 工具接口**拒绝** key 参数（`process_media` 的 diarize 拒 hf_token；#135 后 MCP 面已无任何写配置入口）。
 改凭证相关代码前先读记忆 `videonote-mcp-gotchas`。
 
@@ -108,10 +108,10 @@ docs: 回填 #N commit hash（<hash>）
 
 **查历史档案的姿势**：`grep -n "132" docs/05-优化清单.md` 定位条目，不要全文读。
 
-## 六、当前状态（2026-09-04 基线）
+## 六、当前状态（2026-09-09 基线）
 
-- **10 工具**；#151 全量验证 **981 passed, 1 skipped, 10 subtests passed**。#150 为 973；#149 为 963；#148 为 948。
-- 最近一轮：**#151 Skill 默认由当前 Agent 写笔记**（非多模态才走配置 LLM；`health_check.need_provider` 默认 False）。上一轮 #150 本机 Agent 缓存治理与弹幕取消。#149（协作式取消/生命周期/迁移）；#148（任务成功发布、加密/DAO、manifest/ffprobe）。
+- **10 工具**；全量验证 **1006 passed, 1 skipped, 10 subtests passed**（#151 为 981）。
+- 最近：**抖音登录改为 SSO 扫码**（`videonote login douyin`，与 B 站 / 小宇宙同款终端 ASCII 二维码；`--cookie` 粘贴后备）。上一轮 #151 Skill 默认由当前 Agent 写笔记；#150 本机 Agent 缓存治理与弹幕取消。
 - **部署模型**：本机 Agent（Claude Code / Codex 等）。数据目录视为当前用户受信任目录。batch 旁路普通并发上限是接受的产品语义。CLI `export --out-dir` 允许导出到桌面等任意目录，缺省仍是该任务 `note_results/{task_id}/gen/`。
 - 当前开放 P2：yt-dlp 内部 egress SSRF、manifest 清理跨进程 TOCTOU、stderr 日志路径 no-follow/owner/mode 校验——在本机 Agent 模型下不作为发布阻断；详见 `07-全库代码审查报告.md`。
 - **死代码纪律**：先跑 AST import 图 + 名字引用计数双扫描再动手；`from X import Y` 的 Y 是字符串不是 Name 节点（v1 扫描漏检过）；删函数后 grep 全仓（含 tests/CLI）确认零引用，VENDOR.md 同步，留意 dangling 装饰器/finally。

--- a/docs/02-架构设计.md
+++ b/docs/02-架构设计.md
@@ -79,7 +79,7 @@ Claude Code 插件 `userConfig` 会注入 `VIDEONOTE_*`；跳过的项可能是�
 
 ## MCP 工具（10 个）
 
-凭证红线：**API key / Cookie / HF token 不能经 MCP 工具传入**。填 key 走 `! videonote providers set`；B 站 Cookie 走 `! videonote login bilibili`；小宇宙官方文稿走 `! videonote login xiaoyuzhou`；小红书走 `! videonote login xiaohongshu` / `! videonote setup`。转写全文另可走 **MCP Resource** `videonote://task/{task_id}/transcript`（时间轴纯文本，不占工具数）。
+凭证红线：**API key / Cookie / HF token 不能经 MCP 工具传入**。填 key 走 `! videonote providers set`；B 站 Cookie 走 `! videonote login bilibili`；小宇宙官方文稿走 `! videonote login xiaoyuzhou`；小红书走 `! videonote login xiaohongshu`；抖音走 `! videonote login douyin` / `! videonote setup`。转写全文另可走 **MCP Resource** `videonote://task/{task_id}/transcript`（时间轴纯文本，不占工具数）。
 
 **#135 工具精简（39→18）**：删除全部写配置工具（供应商/模型/转写器/Cookie CRUD——配置修改一律走 CLI，MCP 面零写配置入口）与流水线步骤工具（`fetch_*` / `transcribe_media` / `extract_frames` / `summarize_note`——端到端 `generate_note` 内部已含全部步骤，步骤工具暴露面冗余）。只读配置合并为单一 `get_config`。**#138 再精简（16→10）**：状态/转写/取消合并为单一 `task`（action 分派），清理合并为 `cleanup`，导出/合并/说话人分离合并为 `process_media`，`preflight` 并入 `health_check`。
 

--- a/docs/04-使用手册.md
+++ b/docs/04-使用手册.md
@@ -97,6 +97,8 @@ videonote login bilibili     # 扫码登录，二维码渲染进终端/会话，
 videonote login xiaoyuzhou   # 扫码登录（小宇宙 App）；`--token` 改粘贴
 # 小红书：原生下载器；登录墙/验证码时需要登录态
 videonote login xiaohongshu  # 扫码（本机需 Chrome/Edge）；`--cookie` 改粘贴
+# 抖音：原生下载器；登录墙/风控时需要登录态
+videonote login douyin       # 扫码登录（抖音 App）；`--cookie` 改粘贴
 videonote transcriber set groq                        # 切云端
 ```
 
@@ -127,14 +129,18 @@ get_config()                         # transcriber 段：当前引擎/尺寸/就
 ! videonote login bilibili        # 扫码登录，自动保存 SESSDATA
 ! videonote login xiaoyuzhou      # 扫码登录（小宇宙 App）；`--token` 改粘贴
 ! videonote login xiaohongshu     # 扫码（本机 Chrome/Edge）；`--cookie` 改粘贴
+! videonote login douyin          # 扫码登录（抖音 App）；`--cookie` 改粘贴
 # 或 setup 向导的 Cookie / 登录步骤
 # 非交互：videonote cookie set xiaoyuzhou 'x-jike-access-token=...; x-jike-refresh-token=...'
 # 非交互：videonote cookie set xiaohongshu 'web_session=...; a1=...'
+# 非交互：videonote cookie set douyin 'sessionid=...'
 ```
 
 小宇宙官方文稿接口 `POST /v1/episode-transcript/get` 需要登录态。access token 约 2 小时过期；配了 refresh token 后过期会自动续期。未登录时该期会回退本地下载音频 + ASR（长节目会非常慢）。
 
 小红书走原生笔记页解析（`__INITIAL_STATE__` 视频直链），图文笔记会明确报错。公开视频有时无需登录；遇到登录墙 / 验证码时先 `! videonote login xiaohongshu`（本机需已装 Chrome 或 Edge；扫码走官网登录页，终端出 ASCII 码）。无官方字幕，转写走本地/云端引擎。
+
+抖音走原生 aweme 接口。公开视频有时无需登录；遇到登录墙 / 风控时先 `! videonote login douyin`（终端出 ASCII 码，抖音 App 扫确认）。扫不了可用 `--cookie` 粘贴。
 
 ## 环境变量（可选）
 
@@ -177,7 +183,7 @@ MCP 工具面可被 Agent 以任意输入驱动，防被不可信内容诱导「
 | `inspect_video` | `url`、`platform?` | 只解析：B 站分 P / YouTube 播放列表 → `{kind, entries:[{p,title,url}]}`，url 可直接 `prepare_note_material` / `generate_note` |
 | `task` | `task_id`、`action`（status/transcript/cancel，默认 status）、`segment_range` | status：`{status, message, result?}`；只有 `result.json` 与 manifest 已持久化后才发布 SUCCESS，SUCCESS 时 `result.markdown`（或素材包结果，见 `prepare_note_material`）；**note 任务默认不含完整转写**（避免撑爆 context），要转写用 `action="transcript"`；**素材包任务的转写是主产物，默认直接返回**。transcript：读已完成任务转写（不耗 LLM，按需取）：`{ok, language, segments, full_text, meta}`（默认前 50 段，`"all"` 全文 / `"50-"` / `"0-50"` 按段切片，`meta.truncated` 续取）。cancel：取消进行中/排队的任务（协作式，下一阶段边界生效；运行中返回 `CANCELLING`，排队中可直接 `CANCELLED`，不能硬中断第三方阻塞调用） |
 | `list_tasks` | — | 列出全部任务（全局索引），`[{task_id, title, status, summary, platform, created_at, note_dir}]`，按语义标题识别 |
-| `get_config` | `provider_id`(可选) | **只读配置汇总**：`app_config` 默认值(过滤敏感项) + `providers`(key 掩码) + `transcriber`(引擎/尺寸/就绪) + `cookie_configured`(平台名) + `note_cache`(ttl_days/max_mb)；传 `provider_id` 附加连通性探测。**配置修改一律走 CLI**（`! videonote providers set/transcriber set/login bilibili/login xiaoyuzhou/login xiaohongshu`） |
+| `get_config` | `provider_id`(可选) | **只读配置汇总**：`app_config` 默认值(过滤敏感项) + `providers`(key 掩码) + `transcriber`(引擎/尺寸/就绪) + `cookie_configured`(平台名) + `note_cache`(ttl_days/max_mb)；传 `provider_id` 附加连通性探测。**配置修改一律走 CLI**（`! videonote providers set/transcriber set/login bilibili/login xiaoyuzhou/login xiaohongshu/login douyin`） |
 | `health_check` | `url?`、`provider_id?`、`need_provider`(默认 False) | `server_version` / ffmpeg / 磁盘剩余 / db / 转写器 / keyed_providers / 任务队列；提交前体检，`url` 非空时顺带预解析时长；默认路径不查供应商；走 `generate_note` 后备时 `need_provider=True` |
 | `process_media` | `action`（export/merge/diarize）、`task_id`（export）、`formats`（srt/vtt/json，缺省取 setup「导出格式默认」）、`files`（merge，≥2 个本地路径）、`audio_file`（diarize）、`num_speakers`（diarize，可选）、`out_dir`(可选) | export：确定性导出转写（不耗 LLM），返回 `{task_id, formats:{fmt:"file://路径"}}`；merge：FFmpeg concat 合并多文件为 16kHz mono wav，返回 `{ok, path}`；diarize：说话人分离（pyannote 可选重依赖），**拒绝 hf_token 参数**，token 走 env / setup。该工具保持同步执行，不进入任务注册表，不能通过 `task(action="cancel")` 控制 |
 | `cleanup` | `task_id?`、`include_note`(默认 False)、`include_config`(默认 False)、`include_models`(默认 False)、`dry_run`(默认 False) | 传 `task_id` 按任务清理（删该任务中间产物；`include_note=True` 删整个任务文件夹+索引）；不传 = 全局清空 note_results/static（恢复出厂）+ 清空全局索引；`logs/` 刻意不清（进程持有 fd）；`include_config=True`/`include_models=True` 才清 config/models（**默认拒绝，需 `VIDEONOTE_ALLOW_DESTRUCTIVE_CLEANUP=1` 放行**，#142）；**`dry_run=True` 只预览不删**（#137 行为安全；未放行时对 config/models 标注「将拒绝清理」） |
@@ -273,7 +279,7 @@ generate_note(video_url=..., ..., screenshot=True, format=["screenshot"])
 
 ## 音频增强（多文件合并 / 预处理 / 说话人分离）
 
-- **平台覆盖**：内置 bilibili/youtube/douyin/tiktok/kuaishou/xiaoyuzhou/xiaohongshu/本地文件之外，`inspect_video` 返回 `platform:"generic"`，自动走 **yt-dlp 通用提取**（覆盖 1800+ 站点）；仍失败（登录墙/JS 渲染）才交给 Agent 接手。小宇宙有官方文稿时优先走平台文稿（需 `videonote login xiaoyuzhou`），否则回退 yt-dlp 音频 + 本地 ASR。小红书走原生笔记页解析（需登录时 `videonote login xiaohongshu`），无官方字幕则 ASR。
+- **平台覆盖**：内置 bilibili/youtube/douyin/tiktok/kuaishou/xiaoyuzhou/xiaohongshu/本地文件之外，`inspect_video` 返回 `platform:"generic"`，自动走 **yt-dlp 通用提取**（覆盖 1800+ 站点）；仍失败（登录墙/JS 渲染）才交给 Agent 接手。小宇宙有官方文稿时优先走平台文稿（需 `videonote login xiaoyuzhou`），否则回退 yt-dlp 音频 + 本地 ASR。小红书走原生笔记页解析（需登录时 `videonote login xiaohongshu`），无官方字幕则 ASR。抖音遇登录墙时先 `videonote login douyin`。
 - **多文件合并**：`process_media(action="merge", files=..., out_dir?)` —— 把多段录音/会议分段/多个本地视频合并为一个 16kHz mono wav（FFmpeg concat，自动统一转码），再转写/总结。
 - **音频预处理**（setup ② 勾选或 `videonote transcriber preprocess on`）：转写前把音频归一化为 16kHz mono wav；超长音频（>1800s）自动分块转写并拼接。**默认关**；零额外依赖（FFmpeg）。预处理的 `probe_duration` 是 best-effort：ffprobe 失败返回 0，分块时间偏移回退 1800 秒并记录 warning；这不同于 VideoReader 的严格时长探测。
 - **VideoReader 时长探测**：视频理解/抽帧使用独立 ffprobe，120 秒超时，NaN、Inf、负数或无法解析直接报错，不应与预处理的 0 秒回退混为一谈。
@@ -400,6 +406,7 @@ claude plugin install videonote@videonote
 | 小宇宙走了很久本地转写 | 未配登录态，官方文稿拿不到。让用户 `! videonote login xiaoyuzhou` 后重试（有文稿则跳过 ASR） |
 | 小红书下载失败 / 图文笔记 | 图文笔记无法转写。视频笔记遇登录墙让用户 `! videonote login xiaohongshu` 后重试（需本机 Chrome/Edge；没有就 `--cookie`）。`inspect_video` 应返回 `platform:"xiaohongshu"` |
 | 小红书扫码报 HTTP 406 | 旧版直连接口已被拒。升级后扫码改走本机 Chrome 打开官网。请安装 Google Chrome 后重试，或 `--cookie` 粘贴 |
+| 抖音下载失败 / 登录墙 | 让用户 `! videonote login douyin` 后重试（终端扫码，抖音 App 确认；扫不了 `--cookie`）。`inspect_video` 应返回 `platform:"douyin"` |
 | `process_media`（diarize）报需安装/缺 token | pyannote 可选重依赖：`transcriber diarization on` 引导安装 + 配 HF_TOKEN + 同意模型授权 |
 | 任务长时间卡住 | `task` 看 message；可能视频很长或模型下载中，耐心等待或换小模型 |
 | 中文乱码/内容差 | 检查所选模型能力；`style` 会影响输出格式 |

--- a/docs/06-执行进度.md
+++ b/docs/06-执行进度.md
@@ -439,3 +439,7 @@
 - [x] **health_check**：`need_provider` 默认 False；合集 duration 提示改默认 prepare。
 - [x] **CLI 向导**：Agent 写笔记确认项默认开；忽略旧 `agent_direct=false` 作为分流依据。
 - [x] **契约**（commit `f027229`）：`tests/test_151_batch.py` + PreflightNeedProviderTest 默认跳过供应商检查。全量 **981 passed, 1 skipped, 10 subtests passed**；Ruff F/I 与 `git diff --check` 通过。
+
+## 抖音扫码登录（2026-09-09）
+
+- [x] 抖音登录改为与 B 站 / 小宇宙同款扫码：`videonote login douyin` 走 `sso.douyin.com/get_qrcode/` + `/check_qrconnect/`，终端 ASCII 二维码，抖音 App 确认后保存 sessionid。二维码与登录回调钉 `douyin.com` / `snssdk.com`，跟随走 `PublicOnlySession`。`--cookie` 粘贴后备；setup 向导「③ 其他」加「抖音扫码登录」。凭证不进 MCP、不打印明文。**1006 passed + ruff F/I-clean**。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -884,3 +884,11 @@ v0.1.1 → v0.1.2 的主要变更（详见下方各「维护」节点块；稳�
 - **后备**：仅当 Agent 无法看图，或用户明确要求配置 LLM → `generate_note` / 合集 `batch_generate_notes`。
 - **health_check**：`need_provider` 默认 False；合集预解析提示改为默认 prepare。
 - **验证**：全量 `pytest` **981 passed, 1 skipped, 10 subtests passed**；Ruff F/I、`git diff --check` 通过。
+
+## 抖音扫码登录（2026-09-09 · `login douyin` 默认扫码，981→1006 tests）
+
+- **默认扫码**：`videonote login douyin` 走官网 SSO `sso.douyin.com/get_qrcode/` + `/check_qrconnect/`（aid `6383`），终端 ASCII 二维码，抖音 App 扫确认后跟随官方 `redirect_url` 收集 Cookie（需含 sessionid）写入 `downloader.json`。
+- **安全**：二维码 URL 与登录回调只认 `douyin.com` / `snssdk.com`；出站走 `PublicOnlySession`；凭证不打印明文、不进 MCP。
+- **后备**：`--cookie` 粘贴浏览器 Cookie；setup 向导「③ 其他」加「抖音扫码登录」。
+- Skill / 04 / troubleshooting / VENDOR 同步；改 Skill 后需刷新插件。
+- **验证**：全量 `pytest` **1006 passed, 1 skipped, 10 subtests passed**；Ruff F/I、`git diff --check` 通过。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote"
-version = "0.1.25"
+version = "0.1.26"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/skills/videonote/SKILL.md
+++ b/skills/videonote/SKILL.md
@@ -41,7 +41,7 @@ description: 用 VideoNote-Mcp 的 MCP 工具把视频链接/本地视频（B站
 
 ## 强制规则
 
-1. **必须用 MCP 工具**。凭证例外：本会话 `! videonote providers set`、`! videonote login bilibili`、`! videonote login xiaoyuzhou`、`! videonote login xiaohongshu`。
+1. **必须用 MCP 工具**。凭证例外：本会话 `! videonote providers set`、`! videonote login bilibili`、`! videonote login xiaoyuzhou`、`! videonote login xiaohongshu`、`! videonote login douyin`。
 2. **单视频一回合一个提交**。不要在同一条消息里并行多个 `generate_note` / `prepare_note_material`（客户端不稳）。普通任务在提交锁内预占名额，覆盖排队和执行全生命周期，超限拒绝。`batch_generate_notes` 只用于后备 LLM 的合集/播放列表，绕过普通 admission，由线程池排队。
 3. **默认你自己写笔记**（见上）。后备才走配置 LLM。
 4. **handoff**：只有返回 `handoff: true`（或 generic **下载失败**）才接手。未知 URL 现在是 `generic`（yt-dlp），**不要**一看到非内置平台就当失败。接手：WebFetch / 浏览器取源，或下到本地再 `prepare_note_material` / `generate_note(platform="local")`。

--- a/skills/videonote/reference/tools.md
+++ b/skills/videonote/reference/tools.md
@@ -145,7 +145,7 @@
 
 | 场景 | 操作 |
 |------|------|
-| 配置入口（首次使用） | 用户在 Claude Code 跑 `/videonote-setup`（体检 → 填 key → 转写 → 默认值 → B站扫码 → 数据管理） |
+| 配置入口（首次使用） | 用户在 Claude Code 跑 `/videonote-setup`（体检 → 填 key → 转写 → 默认值 → 平台扫码 → 数据管理） |
 | 给内置供应商填 key | 用户在本会话 `! videonote providers set <id> --api-key 'sk-...'`（隐藏输入、agent 不碰 key） |
 | 查看配置 / 供应商 / 模型 / 转写器 | `get_config()`（只读汇总）；传 `provider_id` 可附加连通性探测 |
 | 自建/新增供应商或设置默认模型 | `! videonote providers add --name ... --base-url ...`（key 缺省隐藏输入） / `! videonote providers test <id> --default <model>`；当前 CLI 不提供删除供应商/模型命令 |
@@ -154,6 +154,7 @@
 | B 站登录/AI 字幕/评论 | 用户在本会话 `! videonote login bilibili` 扫码（二维码渲染进会话终端，存 SESSDATA） |
 | 小宇宙官方文稿 | 用户在本会话 `! videonote login xiaoyuzhou` 用小宇宙 App 扫码（或 `--token` 粘贴）；未登录会回退本地下载+ASR，长节目会非常慢 |
 | 小红书视频笔记 | 用户在本会话 `! videonote login xiaohongshu` 用小红书 App 扫码（或 `--cookie` 粘贴）；图文笔记无法转写；无官方字幕，走转写引擎 |
+| 抖音视频笔记 | 用户在本会话 `! videonote login douyin` 用抖音 App 扫码（或 `--cookie` 粘贴）；公开视频有时无需登录；遇登录墙/风控时需要 |
 | 本地文件 | `prepare_note_material(video_url="file:///绝对/路径/foo%20bar.mp4")` 或普通路径，`platform` 可省略；后备 LLM 用 `generate_note` |
 | 视频理解默认（setup ③） | 用户说「用默认」/ 全自动模式时不传 `video_understanding`/`video_interval` 即套用（默认关/6s） |
 | 评论/弹幕整合默认（setup ③） | 用户说「用默认」/ 全自动模式时不传 `include_comments`/`comments_limit` 即套用（默认关/20 条） |

--- a/skills/videonote/reference/troubleshooting.md
+++ b/skills/videonote/reference/troubleshooting.md
@@ -17,6 +17,7 @@
 | 小宇宙长时间卡在转写 / 想用官方文稿 | 未配登录态会走本地下载+ASR。引导用户 `! videonote login xiaoyuzhou`（终端扫码，小宇宙 App 确认）后重试；扫不了再用 `--token`。`inspect_video` 应返回 `platform:"xiaoyuzhou"` |
 | 小红书下载失败 / 图文笔记 | 图文笔记无法转写。视频遇登录墙/验证码：引导用户 `! videonote login xiaohongshu`（终端扫码，需本机 Chrome/Edge）；扫不了再用 `--cookie`。`inspect_video` 应返回 `platform:"xiaohongshu"` |
 | 小红书扫码报 406 | 旧版直连接口签名已失效。请用户升级 videonote 后重试扫码（走本机 Chrome）；或 `! videonote login xiaohongshu --cookie` |
+| 抖音下载失败 / 登录墙 | 引导用户 `! videonote login douyin`（终端扫码，抖音 App 确认）；扫不了再用 `--cookie`。`inspect_video` 应返回 `platform:"douyin"` |
 | 整合评论/弹幕时评论拿不到 | 未配 B 站 SESSDATA —— 引导用户 `videonote login bilibili`；抓取失败**不阻断**笔记生成（跳过该部分） |
 | 其他平台（非内置平台） | `inspect_video` 返回 `platform:"generic"` → 自动走 **yt-dlp 通用提取**（覆盖 1800+ 站点）；若也失败任务报错 → Agent 接手：WebFetch/浏览器解析视频源后 `generate_note(video_url="/绝对/路径/x.mp4", platform="local")` |
 | generic 下载报需登录/JS 渲染 | 该站点 yt-dlp 无法直接提取 —— Agent 用 WebFetch/浏览器处理登录/验证，或让用户 `videonote setup` 向导里配「平台 Cookie」后重试 |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -348,6 +348,7 @@ class TestLoginYoutube:
         assert "未知平台" in err
         assert "xiaoyuzhou" in err
         assert "xiaohongshu" in err
+        assert "douyin" in err
 
 
 class _FakeXyzResp:
@@ -576,6 +577,191 @@ class TestLoginXiaohongshu:
             cli._login_xiaohongshu([])
         assert ei.value.code == 1
         assert "生成二维码失败" in capsys.readouterr().err
+
+
+class TestLoginDouyin:
+    def test_cookie_flag_saves_without_printing(self, capsys, monkeypatch):
+        import InquirerPy.inquirer as inq_mod
+
+        def _secret(message="", **kwargs):
+            box = mock.Mock()
+            box.execute.return_value = "sessionid=sess-tok; ttwid=aaa"
+            return box
+
+        monkeypatch.setattr(inq_mod, "secret", _secret)
+        monkeypatch.setattr(
+            "app.downloaders.douyin_auth.verify_douyin_login",
+            lambda: "",
+        )
+        cli._login_douyin(["--cookie"])
+        out = _cli_out(capsys)
+        assert "登录态有效" in out
+        assert "sess-tok" not in out
+        capsys.readouterr()
+        cli._cookie_cli(["list"])
+        listed = _cli_out(capsys)
+        assert "douyin" in listed
+        assert "sess-tok" not in listed
+        capsys.readouterr()
+        cli._cookie_cli(["clear", "douyin"])
+
+    def test_cookie_empty_cancels(self, capsys, monkeypatch):
+        import InquirerPy.inquirer as inq_mod
+
+        def _secret(message="", **kwargs):
+            box = mock.Mock()
+            box.execute.return_value = ""
+            return box
+
+        monkeypatch.setattr(inq_mod, "secret", _secret)
+        cli._login_douyin(["--cookie"])
+        assert "已取消" in _cli_out(capsys)
+
+    def test_cookie_without_sessionid_exits(self, capsys, monkeypatch):
+        import InquirerPy.inquirer as inq_mod
+
+        def _secret(message="", **kwargs):
+            box = mock.Mock()
+            box.execute.return_value = "ttwid=only-tt"
+            return box
+
+        monkeypatch.setattr(inq_mod, "secret", _secret)
+        with pytest.raises(SystemExit) as ei:
+            cli._login_douyin(["--cookie"])
+        assert ei.value.code == 1
+        assert "sessionid" in capsys.readouterr().err
+
+    def test_qr_saves_without_printing_session(self, capsys, monkeypatch):
+        class _Auth:
+            def create_qr(self):
+                return {"token": "tok", "url": "https://www.douyin.com/scan?token=tok"}
+
+            def poll_qr(self, token):
+                return {
+                    "status": "3",
+                    "redirect_url": "https://www.douyin.com/?ticket=1",
+                }
+
+            def finalize(self, redirect_url):
+                self.redirect = redirect_url
+
+            def persist(self):
+                from app.services.cookie_manager import CookieConfigManager
+
+                CookieConfigManager().set("douyin", "sessionid=sess-from-qr; ttwid=tt")
+                return ""
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(cli, "_open_douyin_qr_session", lambda: _Auth())
+        monkeypatch.setattr(time, "sleep", lambda *_: None)
+        monkeypatch.setattr(cli, "_print_ascii_qr", lambda data: print(f"QR:{data}", file=sys.stdout))
+        monkeypatch.setattr("builtins.input", lambda *_: "")
+        cli._login_douyin([])
+        out = _cli_out(capsys)
+        assert "已保存抖音登录态" in out
+        assert "sess-from-qr" not in out
+        capsys.readouterr()
+        cli._cookie_cli(["list"])
+        listed = _cli_out(capsys)
+        assert "douyin" in listed
+        assert "sess-from-qr" not in listed
+        capsys.readouterr()
+        cli._cookie_cli(["clear", "douyin"])
+
+    def test_qr_scanned_then_success(self, capsys, monkeypatch):
+        class _Auth:
+            def __init__(self):
+                self.n = 0
+
+            def create_qr(self):
+                return {"token": "tok", "url": "https://www.douyin.com/scan?token=tok"}
+
+            def poll_qr(self, token):
+                self.n += 1
+                if self.n == 1:
+                    return {"status": "2", "redirect_url": ""}
+                return {
+                    "status": "3",
+                    "redirect_url": "https://www.douyin.com/?ticket=1",
+                }
+
+            def finalize(self, redirect_url):
+                pass
+
+            def persist(self):
+                from app.services.cookie_manager import CookieConfigManager
+
+                CookieConfigManager().set("douyin", "sessionid=sess-from-qr")
+                return ""
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(cli, "_open_douyin_qr_session", lambda: _Auth())
+        monkeypatch.setattr(time, "sleep", lambda *_: None)
+        monkeypatch.setattr(cli, "_print_ascii_qr", lambda data: None)
+        monkeypatch.setattr("builtins.input", lambda *_: "")
+        cli._login_douyin([])
+        out = _cli_out(capsys)
+        assert "已扫码" in out
+        assert "已保存抖音登录态" in out
+        capsys.readouterr()
+        cli._cookie_cli(["clear", "douyin"])
+
+    def test_qr_expired(self, capsys, monkeypatch):
+        class _Auth:
+            def create_qr(self):
+                return {"token": "tok", "url": "https://www.douyin.com/scan?token=tok"}
+
+            def poll_qr(self, token):
+                return {"status": "5", "redirect_url": ""}
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(cli, "_open_douyin_qr_session", lambda: _Auth())
+        monkeypatch.setattr(time, "sleep", lambda *_: None)
+        monkeypatch.setattr(cli, "_print_ascii_qr", lambda data: None)
+        monkeypatch.setattr("builtins.input", lambda *_: "")
+        cli._login_douyin([])
+        assert "已过期" in _cli_out(capsys)
+
+    def test_qr_create_failure_exits(self, capsys, monkeypatch):
+        class _Auth:
+            def create_qr(self):
+                raise RuntimeError("sign error")
+
+        monkeypatch.setattr(cli, "_open_douyin_qr_session", lambda: _Auth())
+        with pytest.raises(SystemExit) as ei:
+            cli._login_douyin([])
+        assert ei.value.code == 1
+        assert "生成二维码失败" in capsys.readouterr().err
+
+    def test_qr_finalize_rejects_foreign_host(self, capsys, monkeypatch):
+        class _Auth:
+            def create_qr(self):
+                return {"token": "tok", "url": "https://www.douyin.com/scan?token=tok"}
+
+            def poll_qr(self, token):
+                return {"status": "3", "redirect_url": "https://evil.example/cb"}
+
+            def finalize(self, redirect_url):
+                raise ValueError("登录回调域名不是抖音官方（evil.example）")
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(cli, "_open_douyin_qr_session", lambda: _Auth())
+        monkeypatch.setattr(time, "sleep", lambda *_: None)
+        monkeypatch.setattr(cli, "_print_ascii_qr", lambda data: None)
+        with pytest.raises(SystemExit) as ei:
+            cli._login_douyin([])
+        assert ei.value.code == 1
+        err = capsys.readouterr().err
+        assert "官方" in err
+        assert "evil.example" in err
 
 
 class TestExportCli:

--- a/tests/test_douyin_auth.py
+++ b/tests/test_douyin_auth.py
@@ -1,0 +1,259 @@
+"""抖音扫码登录：SSO get_qrcode / check_qrconnect / 官方域钉死（全 mock，不碰真网）。"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.downloaders.douyin_auth import (
+    QR_EXPIRED,
+    QR_SCANNED,
+    QR_SUCCESS,
+    QR_WAIT,
+    DouyinAuth,
+    _map_qr_status,
+    format_cookie,
+    gen_verify_fp,
+    has_sessionid,
+    is_douyin_qr_url,
+    is_douyin_redirect_url,
+    parse_cookie_string,
+    verify_douyin_login,
+)
+from app.services.cookie_manager import CookieConfigManager
+
+
+class _FakeCookie:
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+
+class _FakeJar:
+    def __init__(self, initial=None):
+        self._d = dict(initial or {})
+
+    def set(self, name, value, domain=None):
+        self._d[name] = value
+
+    def __iter__(self):
+        for k, v in self._d.items():
+            yield _FakeCookie(name=k, value=v)
+
+
+class _FakeResp:
+    def __init__(self, status=200, payload=None, content=b"{}"):
+        self.status_code = status
+        self._payload = payload
+        self.content = b"{}" if payload is not None else content
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("not json")
+        return self._payload
+
+
+class _FakeSession:
+    def __init__(self, handler):
+        self.headers = {}
+        self.cookies = _FakeJar()
+        self.handler = handler
+        self.closed = False
+        self.calls = []
+
+    def get(self, url, params=None, timeout=None, **kwargs):
+        self.calls.append((url, params or {}))
+        return self.handler(url, params)
+
+    def close(self):
+        self.closed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _qr_payload(token="tok-1", url="https://www.douyin.com/scan?token=tok-1"):
+    return {
+        "error_code": 0,
+        "message": "success",
+        "data": {"token": token, "qrcode_index_url": url},
+    }
+
+
+class UrlAndCookieHelpersTest(unittest.TestCase):
+    def test_qr_and_redirect_hosts(self):
+        self.assertTrue(is_douyin_qr_url("https://www.douyin.com/scan?token=x"))
+        self.assertTrue(is_douyin_qr_url("https://aweme.snssdk.com/service/2/web/redirect/"))
+        self.assertFalse(is_douyin_qr_url("https://evil.com/scan"))
+        self.assertFalse(is_douyin_qr_url("https://douyin.com.evil.com/scan"))
+        self.assertTrue(is_douyin_redirect_url("https://sso.douyin.com/login/callback"))
+        self.assertFalse(is_douyin_redirect_url("https://evil.example/redirect"))
+
+    def test_parse_and_sessionid(self):
+        parsed = parse_cookie_string("sessionid=abc; ttwid=tt; sessionid_ss=ss")
+        self.assertEqual(parsed["sessionid"], "abc")
+        self.assertTrue(has_sessionid(parsed))
+        self.assertTrue(has_sessionid({"sessionid_ss": "only-ss"}))
+        self.assertFalse(has_sessionid({"ttwid": "tt"}))
+        self.assertEqual(format_cookie({"a": "1", "b": ""}), "a=1")
+
+    def test_verify_fp_shape(self):
+        fp = gen_verify_fp()
+        self.assertTrue(fp.startswith("verify_"))
+        self.assertGreaterEqual(fp.count("_"), 5)
+
+    def test_map_qr_status(self):
+        self.assertEqual(_map_qr_status({"status": "1"}), QR_WAIT)
+        self.assertEqual(_map_qr_status({"status": "2"}), QR_SCANNED)
+        self.assertEqual(_map_qr_status({"status": "3"}), QR_SUCCESS)
+        self.assertEqual(
+            _map_qr_status({"status": "4", "redirect_url": "https://www.douyin.com/"}),
+            QR_SUCCESS,
+        )
+        self.assertEqual(_map_qr_status({"redirect_url": "https://www.douyin.com/"}), QR_SUCCESS)
+        self.assertEqual(_map_qr_status({"status": "5"}), QR_EXPIRED)
+
+
+class DouyinAuthQrTest(unittest.TestCase):
+    def test_create_qr_returns_official_url(self):
+        def handler(url, params):
+            if "get_qrcode" in url:
+                return _FakeResp(payload=_qr_payload())
+            return _FakeResp(payload={})
+
+        auth = DouyinAuth(session=_FakeSession(handler))
+        created = auth.create_qr()
+        self.assertEqual(created["token"], "tok-1")
+        self.assertIn("douyin.com", created["url"])
+
+    def test_create_qr_rejects_foreign_host(self):
+        def handler(url, params):
+            if "get_qrcode" in url:
+                return _FakeResp(payload=_qr_payload(url="https://evil.example/qr"))
+            return _FakeResp(payload={})
+
+        auth = DouyinAuth(session=_FakeSession(handler))
+        with self.assertRaises(RuntimeError) as ei:
+            auth.create_qr()
+        self.assertIn("官方域名", str(ei.exception))
+
+    def test_create_qr_missing_token(self):
+        def handler(url, params):
+            if "get_qrcode" in url:
+                return _FakeResp(payload={"error_code": 1, "message": "风控", "data": {}})
+            return _FakeResp(payload={})
+
+        auth = DouyinAuth(session=_FakeSession(handler))
+        with self.assertRaises(RuntimeError) as ei:
+            auth.create_qr()
+        self.assertIn("风控", str(ei.exception))
+
+    def test_poll_scanned_then_success(self):
+        payloads = [
+            {"data": {"status": "1"}},
+            {"data": {"status": "2"}},
+            {
+                "data": {
+                    "status": "3",
+                    "redirect_url": "https://www.douyin.com/?ticket=1",
+                }
+            },
+        ]
+
+        def handler(url, params):
+            if "check_qrconnect" in url:
+                return _FakeResp(payload=payloads.pop(0))
+            return _FakeResp(payload={})
+
+        auth = DouyinAuth(session=_FakeSession(handler))
+        self.assertEqual(auth.poll_qr("tok").get("status"), QR_WAIT)
+        self.assertEqual(auth.poll_qr("tok").get("status"), QR_SCANNED)
+        poll = auth.poll_qr("tok")
+        self.assertEqual(poll["status"], QR_SUCCESS)
+        self.assertTrue(poll["redirect_url"].startswith("https://www.douyin.com"))
+
+    def test_poll_expired(self):
+        def handler(url, params):
+            return _FakeResp(payload={"data": {"status": "5"}})
+
+        auth = DouyinAuth(session=_FakeSession(handler))
+        self.assertEqual(auth.poll_qr("tok")["status"], QR_EXPIRED)
+
+    def test_finalize_rejects_foreign_host(self):
+        auth = DouyinAuth(session=_FakeSession(lambda *a: _FakeResp(payload={})))
+        with self.assertRaises(ValueError) as ei:
+            auth.finalize("https://evil.example/callback")
+        self.assertIn("官方", str(ei.exception))
+
+    def test_finalize_empty_is_noop(self):
+        session = _FakeSession(lambda *a: _FakeResp(payload={}))
+        auth = DouyinAuth(session=session)
+        auth.finalize("")
+        self.assertEqual(session.calls, [])
+
+    def test_persist_saves_sessionid_without_exposing_it(self):
+        with tempfile.TemporaryDirectory() as td:
+            mgr = CookieConfigManager(filepath=str(Path(td) / "downloader.json"))
+            jar = _FakeJar({"sessionid": "sess-secret", "ttwid": "tt"})
+
+            def handler(url, params):
+                if "account/info" in url:
+                    return _FakeResp(payload={"data": {"user_id": "123", "name": "u"}})
+                return _FakeResp(payload={})
+
+            session = _FakeSession(handler)
+            session.cookies = jar
+            auth = DouyinAuth(session=session, cookie_mgr=mgr)
+            with mock.patch("app.downloaders.douyin_auth.PublicOnlySession", return_value=session):
+                err = auth.persist()
+            self.assertEqual(err, "")
+            saved = mgr.get("douyin") or ""
+            self.assertIn("sessionid=sess-secret", saved)
+            self.assertNotIn("sess-secret", str(err))
+
+    def test_persist_missing_sessionid(self):
+        with tempfile.TemporaryDirectory() as td:
+            mgr = CookieConfigManager(filepath=str(Path(td) / "downloader.json"))
+            auth = DouyinAuth(session=_FakeSession(lambda *a: _FakeResp()), cookie_mgr=mgr)
+            self.assertIn("未取到 sessionid", auth.persist())
+            self.assertFalse(mgr.get("douyin"))
+
+    def test_close_does_not_close_injected_session(self):
+        session = _FakeSession(lambda *a: _FakeResp())
+        auth = DouyinAuth(session=session)
+        auth.close()
+        self.assertFalse(session.closed)
+
+
+class VerifyDouyinLoginTest(unittest.TestCase):
+    def test_missing_cookie(self):
+        with tempfile.TemporaryDirectory() as td:
+            mgr = CookieConfigManager(filepath=str(Path(td) / "downloader.json"))
+            self.assertIn("未配置", verify_douyin_login(cookie_mgr=mgr))
+
+    def test_ok(self):
+        with tempfile.TemporaryDirectory() as td:
+            mgr = CookieConfigManager(filepath=str(Path(td) / "downloader.json"))
+            mgr.set("douyin", "sessionid=abc; ttwid=tt")
+            session = _FakeSession(
+                lambda url, params: _FakeResp(payload={"data": {"user_id": "1", "name": "u"}})
+            )
+            with mock.patch("app.downloaders.douyin_auth.PublicOnlySession", return_value=session):
+                self.assertEqual(verify_douyin_login(cookie_mgr=mgr), "")
+
+    def test_unauthorized(self):
+        with tempfile.TemporaryDirectory() as td:
+            mgr = CookieConfigManager(filepath=str(Path(td) / "downloader.json"))
+            mgr.set("douyin", "sessionid=abc")
+            session = _FakeSession(lambda url, params: _FakeResp(status=401, payload={}))
+            with mock.patch("app.downloaders.douyin_auth.PublicOnlySession", return_value=session):
+                err = verify_douyin_login(cookie_mgr=mgr)
+            self.assertIn("无效", err)
+            self.assertNotIn("abc", err)

--- a/uv.lock
+++ b/uv.lock
@@ -4058,7 +4058,7 @@ wheels = [
 
 [[package]]
 name = "videonote"
-version = "0.1.25"
+version = "0.1.26"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.25"
+__version__ = "0.1.26"

--- a/videonote_mcp/cli.py
+++ b/videonote_mcp/cli.py
@@ -653,6 +653,7 @@ def _wizard_other(inq) -> None:
                     {"name": "B 站扫码登录（自动获取 SESSDATA，AI 字幕用）", "value": "bili-login"},
                     {"name": "小宇宙扫码登录（官方文稿用，App 扫一扫）", "value": "xyz-login"},
                     {"name": "小红书扫码登录（下载视频笔记用，App 扫一扫）", "value": "xhs-login"},
+                    {"name": "抖音扫码登录（下载视频笔记用，App 扫一扫）", "value": "dy-login"},
                     {"name": "平台 Cookie（手动填，B 站等需登录内容）", "value": "cookie"},
                     {"name": f"默认笔记位置（图片模式）：{notes_dir}", "value": "notes"},
                     {"name": f"视频理解默认（{'开' if vu_on else '关'} / {vu_int}s，需多模态模型）", "value": "video"},
@@ -671,6 +672,8 @@ def _wizard_other(inq) -> None:
                 _login_xiaoyuzhou([], exit_on_fail=False)
             elif pick == "xhs-login":
                 _login_xiaohongshu([], exit_on_fail=False)
+            elif pick == "dy-login":
+                _login_douyin([], exit_on_fail=False)
             elif pick == "cookie":
                 _show_header("平台 Cookie")
                 platform = inq.select(
@@ -1482,6 +1485,7 @@ def _cookie_cli(argv) -> None:
     B 站推荐 `videonote login bilibili` 扫码登录（AI 字幕需要 SESSDATA）。
     小宇宙官方文稿需要登录态（推荐 `videonote login xiaoyuzhou` 扫码）。
     小红书视频下载推荐 `videonote login xiaohongshu` 扫码（登录墙/验证码时需要）。
+    抖音下载推荐 `videonote login douyin` 扫码（登录墙/风控时需要）。
     """
     parser = argparse.ArgumentParser(
         prog="videonote cookie",
@@ -1993,6 +1997,162 @@ def _login_xiaohongshu(args, exit_on_fail: bool = True) -> None:
     _login_xiaohongshu_qr(exit_on_fail)
 
 
+def _login_douyin_cookie(exit_on_fail: bool = True) -> None:
+    print("请在电脑浏览器登录 https://www.douyin.com 后：", file=sys.stdout)
+    print("1. 按 F12 → Network → 刷新 → 点任意 www.douyin.com 请求", file=sys.stdout)
+    print("2. Request Headers 里复制完整 Cookie 行（需含 sessionid）", file=sys.stdout)
+    try:
+        from InquirerPy import inquirer as inq
+    except ImportError:
+        print("需要 InquirerPy：`uv sync` 后重试", file=sys.stderr)
+        if exit_on_fail:
+            sys.exit(1)
+        return
+    cookie = inq.secret(message="抖音 Cookie 字符串（留空取消）", keybindings=_KB).execute()
+    if not cookie or not cookie.strip():
+        print("已取消", file=sys.stdout)
+        return
+    from app.downloaders.douyin_auth import (
+        has_sessionid,
+        parse_cookie_string,
+        verify_douyin_login,
+    )
+    from app.services.cookie_manager import CookieConfigManager
+
+    if not has_sessionid(parse_cookie_string(cookie)):
+        print("未发现 sessionid，请复制完整 Cookie 行后重试", file=sys.stderr)
+        if exit_on_fail:
+            sys.exit(1)
+        return
+    CookieConfigManager().set("douyin", cookie.strip())
+    err = verify_douyin_login()
+    if not err:
+        print(f"{_GREEN}✓ 抖音登录态有效{_RESET}", file=sys.stdout)
+        return
+    print(f"{_YELLOW}⚠ {err}（配置已保存，下载时若仍失败可重试扫码）{_RESET}", file=sys.stdout)
+
+
+def _open_douyin_qr_session():
+    """SSO 扫码会话。测试可 patch 此工厂。"""
+    from app.downloaders.douyin_auth import DouyinAuth
+
+    return DouyinAuth()
+
+
+def _login_douyin_qr(exit_on_fail: bool = True) -> None:
+    """官网 SSO 扫码：get_qrcode → 终端 ASCII 二维码 → 轮询 check_qrconnect。"""
+    import time
+
+    try:
+        import qrcode  # noqa: F401
+    except ImportError:
+        print("需要 qrcode 库：`uv sync` 后重试", file=sys.stderr)
+        if exit_on_fail:
+            sys.exit(1)
+        return
+
+    from app.downloaders.douyin_auth import (
+        QR_EXPIRED,
+        QR_SCANNED,
+        QR_SUCCESS,
+        is_douyin_qr_url,
+    )
+
+    session = _open_douyin_qr_session()
+    try:
+        created = session.create_qr()
+    except Exception as e:
+        print(f"生成二维码失败: {e}", file=sys.stderr)
+        print("扫不了可改用 `videonote login douyin --cookie` 粘贴 Cookie", file=sys.stderr)
+        if exit_on_fail:
+            sys.exit(1)
+        return
+    qr_url = created.get("url") or ""
+    token = created.get("token") or ""
+    if not qr_url or not token:
+        print("生成二维码失败：接口未返回 url/token", file=sys.stderr)
+        if exit_on_fail:
+            sys.exit(1)
+        return
+    if not is_douyin_qr_url(qr_url):
+        print("生成二维码失败：返回的二维码地址不是官方域名", file=sys.stderr)
+        if exit_on_fail:
+            sys.exit(1)
+        return
+
+    _show_header("抖音扫码登录")
+    print(f"{_YELLOW}请用抖音 App「扫一扫」扫描下方二维码（约 3 分钟内有效）{_RESET}", file=sys.stdout)
+    print("扫不了可改用 `videonote login douyin --cookie` 粘贴 Cookie", file=sys.stdout)
+    _print_ascii_qr(qr_url)
+
+    last_status = None
+    try:
+        for _ in range(90):
+            time.sleep(2)
+            try:
+                poll = session.poll_qr(token)
+            except Exception as e:
+                print(f"轮询失败（网络？）: {e}", file=sys.stderr)
+                continue
+            st = poll.get("status")
+            if st == QR_SUCCESS:
+                try:
+                    session.finalize(poll.get("redirect_url") or "")
+                except Exception as e:
+                    print(f"{e}", file=sys.stderr)
+                    if exit_on_fail:
+                        sys.exit(1)
+                    return
+                err = session.persist()
+                if err and err.startswith("登录成功但未取到"):
+                    print("登录成功但未取到 sessionid，请改用 `videonote login douyin --cookie`", file=sys.stderr)
+                    if exit_on_fail:
+                        sys.exit(1)
+                    return
+                if err and err.startswith("请求失败"):
+                    print(f"{_YELLOW}⚠ {err}（cookie 已保存）{_RESET}", file=sys.stdout)
+                elif err and ("无效" in err or "未能确认" in err):
+                    print(f"{_YELLOW}⚠ {err}{_RESET}", file=sys.stdout)
+                else:
+                    print(f"{_GREEN}✓ 已保存抖音登录态 —— 下载视频笔记可用了{_RESET}", file=sys.stdout)
+                try:
+                    input("（按回车返回）")
+                except (EOFError, KeyboardInterrupt):
+                    pass
+                return
+            if st == QR_SCANNED and last_status != QR_SCANNED:
+                print("已扫码，请在手机上确认登录…", file=sys.stdout)
+                last_status = QR_SCANNED
+            elif st == QR_EXPIRED:
+                print(f"{_YELLOW}二维码已过期，请重新运行 `videonote login douyin`{_RESET}", file=sys.stdout)
+                try:
+                    input("（按回车返回）")
+                except (EOFError, KeyboardInterrupt):
+                    pass
+                return
+        print(f"{_YELLOW}二维码已过期，请重新运行 `videonote login douyin`{_RESET}", file=sys.stdout)
+    except KeyboardInterrupt:
+        print("（已取消）", file=sys.stdout)
+    finally:
+        close = getattr(session, "close", None)
+        if callable(close):
+            close()
+
+
+def _login_douyin(args, exit_on_fail: bool = True) -> None:
+    """`videonote login douyin`：默认扫码；`--cookie` 粘贴浏览器 Cookie。"""
+    parser = argparse.ArgumentParser(
+        prog="videonote login douyin",
+        description="抖音登录：默认扫码；--cookie 改粘贴浏览器 Cookie",
+    )
+    parser.add_argument("--cookie", action="store_true", help="粘贴 Cookie 而不是扫码")
+    opts = parser.parse_args(args)
+    if opts.cookie:
+        _login_douyin_cookie(exit_on_fail)
+        return
+    _login_douyin_qr(exit_on_fail)
+
+
 def _bilibili_sessdata_from_login_url(login_url: str, headers: dict) -> str:
     """从扫码成功 URL 取 SESSDATA：官方 host 钉死 + PublicOnlySession 跟随（#145 A1）。
 
@@ -2019,12 +2179,13 @@ def _bilibili_sessdata_from_login_url(login_url: str, headers: dict) -> str:
 
 
 def _login_cli(argv, exit_on_fail: bool = True) -> None:
-    """`videonote login [bilibili|youtube|xiaoyuzhou|xiaohongshu]`：平台登录配置。
+    """`videonote login [bilibili|youtube|xiaoyuzhou|xiaohongshu|douyin]`：平台登录配置。
 
     - bilibili：扫码登录，自动获取并保存 SESSDATA（AI 字幕用）
     - youtube：读浏览器登录态或手动粘贴 Cookie（--browser 时实测验证）
     - xiaoyuzhou：扫码登录（`--token` 改粘贴 x-jike token）
     - xiaohongshu：扫码登录（`--cookie` 改粘贴浏览器 Cookie）
+    - douyin：扫码登录（`--cookie` 改粘贴浏览器 Cookie）
 
     exit_on_fail=False 时失败路径只返回不杀进程（setup 向导内调用，#120：
     登录失败不再让整个向导带 traceback/退出，已配的其它设置不丢失）。
@@ -2038,8 +2199,11 @@ def _login_cli(argv, exit_on_fail: bool = True) -> None:
     if argv and argv[0] == "xiaohongshu":
         _login_xiaohongshu(argv[1:], exit_on_fail)
         return
+    if argv and argv[0] == "douyin":
+        _login_douyin(argv[1:], exit_on_fail)
+        return
     if argv and argv[0] != "bilibili":
-        print(f"未知平台: {argv[0]}（支持 bilibili / youtube / xiaoyuzhou / xiaohongshu）", file=sys.stderr)
+        print(f"未知平台: {argv[0]}（支持 bilibili / youtube / xiaoyuzhou / xiaohongshu / douyin）", file=sys.stderr)
         sys.exit(2)
     import time
 

--- a/videonote_mcp/server.py
+++ b/videonote_mcp/server.py
@@ -894,7 +894,7 @@ def _resolve_default_provider_id() -> Optional[str]:
 _SENSITIVE_VIA_MCP = (
     "API key / Cookie / HF token 不能经 MCP 工具传入（会进对话上游）。"
     "请在本会话终端执行：`! videonote providers set <id> --api-key '...'` "
-    "或 `! videonote login bilibili` / `! videonote setup`。"
+    "或 `! videonote login bilibili` / `! videonote login douyin` / `! videonote setup`。"
 )
 
 
@@ -2096,7 +2096,7 @@ def get_config(provider_id: str = "") -> str:
 
     配置修改一律走 CLI（MCP 面不提供写配置工具，凭证红线最干净）：
     `! videonote providers set <id> --api-key '...'` / `! videonote login bilibili` /
-    `! videonote login xiaohongshu` / `! videonote transcriber set ...` / `! videonote transcriber download ...`
+    `! videonote login xiaohongshu` / `! videonote login douyin` / `! videonote transcriber set ...` / `! videonote transcriber download ...`
     """
     raw = get_app_config()
     _blocked = ("token", "cookie", "api_key", "secret", "password")


### PR DESCRIPTION
## Summary
- 同步 `origin/main` 的 README 致谢改动（PR #43）到 `dev`，再叠加强音扫码登录：`videonote login douyin` 默认走官网 SSO（`get_qrcode` + `check_qrconnect`），终端 ASCII 二维码，确认后保存 sessionid；`--cookie` 粘贴为后备。二维码与登录回调钉 `douyin.com` / `snssdk.com`。
- 测试基线 981 → **1006 passed, 1 skipped, 10 subtests**；Ruff F/I 干净。
- 四处版本对齐到 **0.1.26**（`pyproject.toml` / `__init__.py` / `plugin.json` / `uv.lock`）。合并后打 **新标签** `v0.1.26`，触发 `release.yml` → GitHub Release + PyPI Trusted Publishing。
- Skill 行为变更：合并后需 `claude plugin disable videonote@videonote` 再 `install` 才拿到新 SKILL。MCP 走 `uvx videonote@latest` 会在发版后自动取 0.1.26。

## Test plan
- [x] 本机全量 `1006 passed, 1 skipped, 10 subtests` + ruff F/I-clean + `git diff --check`
- [x] 四处版本字符串均为 `0.1.26`
- [ ] CI Smoke test 绿（Python 3.11/3.12/3.13）
- [ ] 合并后打 `v0.1.26` tag，确认 release.yml：四处版本一致 + 测试门禁 + wheel 内容 + MCP handshake + PyPI 发布
- [ ] 发布后 `uvx videonote@0.1.26` 能启动，`health_check` 的 `server_version` 为 `0.1.26`
- [ ] 合并后 `origin/dev` **快进**到 `origin/main`（不要再开同步 merge commit）


Made with [Cursor](https://cursor.com)