### PR TITLE
release: v0.1.28（抖音扫码确认后不再卡住）

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "videonote",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "Generate AI Markdown notes from video links (Bilibili/YouTube/Douyin/Kuaishou/Xiaoyuzhou/Xiaohongshu/local)",
   "author": {
     "name": "HuangYincan",

--- a/app/downloaders/douyin_auth.py
+++ b/app/downloaders/douyin_auth.py
@@ -132,16 +132,20 @@ def _is_html_response(resp) -> bool:
 
 
 def _map_qr_status(data: dict) -> str:
-    """把 SSO / passport data.status / redirect_url 归一成 QR_* 常量。"""
+    """把 SSO / passport data.status / redirect_url 归一成 QR_* 常量。
+
+    旧 SSO 数字：1 等待 / 2 已扫 / 3·4 成功（4 常带 redirect_url）/ 5 过期。
+    passport/web：new / scanned / confirmed；4 / refused / expired 是失效刷新。
+    """
     redirect = (data.get("redirect_url") or "") if isinstance(data, dict) else ""
     raw = ""
     if isinstance(data, dict):
         raw = str(data.get("status", "") or "").strip().lower()
-    if redirect or raw in ("3", "4", "confirmed", "success"):
+    if redirect or raw in ("3", "confirmed", "success"):
         return QR_SUCCESS
     if raw in ("2", "scanned", "scanning"):
         return QR_SCANNED
-    if raw in ("5", "expired", "expire", "canceled", "cancelled"):
+    if raw in ("4", "5", "expired", "expire", "canceled", "cancelled", "refused"):
         return QR_EXPIRED
     return QR_WAIT
 

--- a/app/downloaders/douyin_browser.py
+++ b/app/downloaders/douyin_browser.py
@@ -2,15 +2,20 @@
 
 直连 `sso.douyin.com/get_qrcode/` 会被 ByteDance 风控成 HTML（HTTP 200）。
 登录页在真实 Chrome 里自己打 `passport/web/get_qrcode`；我们拦截 JSON 拿
-二维码 URL，终端仍出 ASCII 码，轮询期间保持页面存活（站点自己打 check_qrconnect）。
+二维码 URL，终端仍出 ASCII 码。官网 `is_frontier` 时「已确认」可能只走
+WebSocket，HTTP 会一直停在 scanned——因此轮询时用本机 Chrome 上下文
+主动打 check_qrconnect（关掉 is_frontier），不只等拦截。
 """
 from __future__ import annotations
 
+import json
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse, urlsplit, urlunsplit
 
 from app.downloaders.douyin_auth import (
     HOME,
+    QR_EXPIRED,
+    QR_SCANNED,
     QR_SUCCESS,
     QR_WAIT,
     _map_qr_status,
@@ -40,6 +45,49 @@ _LAUNCH_TRIES = (
 
 class BrowserQrUnavailable(RuntimeError):
     """本机没有可用的 Playwright / Chrome。"""
+
+
+def rewrite_qrconnect_url(url: str, token: str) -> str:
+    """get_qrcode / check_qrconnect → 短轮询 URL（关掉 is_frontier，钉官方域）。"""
+    if not url or not token:
+        return ""
+    if not host_matches(url, "douyin.com"):
+        return ""
+    parts = urlsplit(url)
+    path = parts.path or "/passport/web/check_qrconnect/"
+    if "get_qrcode" in path:
+        path = path.replace("get_qrcode", "check_qrconnect")
+    elif "check_qrconnect" not in path:
+        path = "/passport/web/check_qrconnect/"
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    query["token"] = token
+    query["is_frontier"] = "0"
+    return urlunsplit((parts.scheme or "https", parts.netloc, path, urlencode(query), ""))
+
+
+def poll_payload_status(body: dict) -> tuple[str, str]:
+    """从 check_qrconnect / WS JSON 抽出 (QR_*, redirect_url)。"""
+    if not isinstance(body, dict):
+        return QR_WAIT, ""
+    data = body.get("data") if isinstance(body.get("data"), dict) else None
+    if not isinstance(data, dict):
+        data = body
+    st = _map_qr_status(data)
+    redir = str(data.get("redirect_url") or body.get("redirect_url") or "")
+    return st, redir
+
+
+def next_qr_status(current: str, incoming: str) -> str:
+    """扫码状态只前进，避免 frontier 下后续 HTTP scanned/new 把 confirmed 盖掉。"""
+    if incoming == QR_EXPIRED:
+        return QR_EXPIRED
+    if current == QR_SUCCESS:
+        return QR_SUCCESS
+    if incoming == QR_SUCCESS:
+        return QR_SUCCESS
+    if current == QR_SCANNED and incoming == QR_WAIT:
+        return QR_SCANNED
+    return incoming
 
 
 def parse_qr_create_payload(body: dict) -> dict:
@@ -87,6 +135,43 @@ class DouyinBrowserQr:
         self._status = QR_WAIT
         self._redirect = ""
         self._logged_cookies: dict = {}
+        self._source_url = ""
+
+    def _apply_poll_body(self, body: dict) -> None:
+        st, redir = poll_payload_status(body)
+        prev = self._status
+        self._status = next_qr_status(self._status, st)
+        if redir:
+            self._redirect = redir
+        if self._status != prev:
+            logger.info("抖音扫码状态: %s", self._status)
+
+    def _on_ws_payload(self, payload) -> None:
+        text = payload
+        if isinstance(payload, dict):
+            text = payload.get("payload") or payload.get("data") or ""
+        if isinstance(text, bytes):
+            try:
+                text = text.decode("utf-8", "replace")
+            except Exception:  # noqa: BLE001
+                return
+        if not isinstance(text, str) or not text or text[0] not in "{[":
+            return
+        try:
+            body = json.loads(text)
+        except Exception:  # noqa: BLE001
+            return
+        if isinstance(body, dict):
+            self._apply_poll_body(body)
+
+    def _on_websocket(self, ws) -> None:
+        url = getattr(ws, "url", "") or ""
+        if not host_matches(url, "douyin.com", "snssdk.com"):
+            return
+        try:
+            ws.on("framereceived", self._on_ws_payload)
+        except Exception:  # noqa: BLE001
+            pass
 
     def _on_response(self, resp) -> None:
         url = resp.url or ""
@@ -102,16 +187,33 @@ class DouyinBrowserQr:
             parsed = parse_qr_create_payload(body)
             if parsed.get("url") and is_douyin_qr_url(parsed["url"]) and parsed.get("token"):
                 self._created = parsed
+                self._source_url = url
             return
         if _POLL_MARK in url:
-            data = body.get("data") if isinstance(body.get("data"), dict) else {}
-            st = _map_qr_status(data if isinstance(data, dict) else {})
-            self._status = st
-            redir = ""
-            if isinstance(data, dict):
-                redir = str(data.get("redirect_url") or "")
-            if redir:
-                self._redirect = redir
+            self._source_url = self._source_url or url
+            self._apply_poll_body(body)
+
+    def _poll_request_url(self, token: str) -> str:
+        source = self._source_url or f"{HOME}/passport/web/check_qrconnect/?aid=6383"
+        return rewrite_qrconnect_url(source, token)
+
+    def _active_poll(self, token: str) -> None:
+        if not token or self._page is None:
+            return
+        url = self._poll_request_url(token)
+        if not url:
+            return
+        try:
+            resp = self._page.request.get(url, timeout=8000)
+        except Exception as exc:  # noqa: BLE001
+            logger.info("抖音主动轮询失败: %s", sanitize_error_text(exc))
+            return
+        try:
+            body = resp.json()
+        except Exception:  # noqa: BLE001
+            return
+        if isinstance(body, dict):
+            self._apply_poll_body(body)
 
     def _launch(self) -> None:
         try:
@@ -152,6 +254,7 @@ class DouyinBrowserQr:
         )
         self._page = self._context.new_page()
         self._page.on("response", self._on_response)
+        self._page.on("websocket", self._on_websocket)
 
     def _cookies(self) -> dict:
         if self._context is None:
@@ -205,10 +308,11 @@ class DouyinBrowserQr:
             raise
 
     def poll_qr(self, token: str) -> dict:
-        """抽一次站点轮询结果；内部 wait 以便 Playwright 收包。"""
+        """主动短轮询 check_qrconnect，并抽一次页面事件（WS / 拦截）。"""
+        self._active_poll(token)
         if self._page is not None:
             try:
-                self._page.wait_for_timeout(2000)
+                self._page.wait_for_timeout(500)
             except Exception:  # noqa: BLE001
                 pass
         cookies = self._cookies()

--- a/docs/00-新手上路.md
+++ b/docs/00-新手上路.md
@@ -21,7 +21,7 @@ VideoNote-Mcp：把「视频 → AI Markdown 笔记」封装成 MCP server（10 
 | `app/` | **vendored 流水线** + 本仓库分叉：`services/`（note、pipeline、merge、diarization）、`downloaders/`、`transcriber/`、`gpt/`、`db/`（engine + DAO）、`utils/`、`models/`、`enmus/` | 见 `VENDOR.md` 分叉清单——再 sync 上游**不要**当「4 处补丁」重打 |
 | `skills/videonote/` | 用户侧 Skill（SKILL.md + reference/）| 改行为要同步 tools.md |
 | `.claude-plugin/` | marketplace + plugin.json（userConfig env 映射）| 加配置项要同步 plugin.json |
-| `tests/` | 契约与回归（pytest + unittest 混用，conftest 做隔离）。#151 全量验证基线为 981；当前 **1019** | 新行为必须补测试 |
+| `tests/` | 契约与回归（pytest + unittest 混用，conftest 做隔离）。#151 全量验证基线为 981；当前 **1024** | 新行为必须补测试 |
 | `docs/` | 中文文档（本文件 + 索引 + 手册 + 审计史）| 改行为同步 04 手册 |
 | `data/` | 源码 checkout 运行时数据（SQLite、note_results、models、config，gitignored）| 安装模式在 `~/.local/share/videonote-mcp/` |
 
@@ -110,8 +110,8 @@ docs: 回填 #N commit hash（<hash>）
 
 ## 六、当前状态（2026-09-10 基线）
 
-- **10 工具**；全量验证 **1019 passed, 1 skipped, 10 subtests passed**（#151 为 981）。
-- 最近：**抖音扫码改本机 Chrome**（`sso.douyin.com/get_qrcode/` 对普通 TLS 返回 HTML 风控页；与小红书同款拦截官网登录页出码）。上一轮：抖音登录改为扫码；#151 Skill 默认由当前 Agent 写笔记；#150 本机 Agent 缓存治理与弹幕取消。
+- **10 工具**；全量验证 **1024 passed, 1 skipped, 10 subtests passed**（#151 为 981）。
+- 最近：**抖音扫码确认后 CLI 卡住**（frontier 下 confirmed 走 WebSocket；改为主动短轮询 check_qrconnect）。上一轮：扫码改本机 Chrome；#151 Skill 默认由当前 Agent 写笔记。
 - **部署模型**：本机 Agent（Claude Code / Codex 等）。数据目录视为当前用户受信任目录。batch 旁路普通并发上限是接受的产品语义。CLI `export --out-dir` 允许导出到桌面等任意目录，缺省仍是该任务 `note_results/{task_id}/gen/`。
 - 当前开放 P2：yt-dlp 内部 egress SSRF、manifest 清理跨进程 TOCTOU、stderr 日志路径 no-follow/owner/mode 校验——在本机 Agent 模型下不作为发布阻断；详见 `07-全库代码审查报告.md`。
 - **死代码纪律**：先跑 AST import 图 + 名字引用计数双扫描再动手；`from X import Y` 的 Y 是字符串不是 Name 节点（v1 扫描漏检过）；删函数后 grep 全仓（含 tests/CLI）确认零引用，VENDOR.md 同步，留意 dangling 装饰器/finally。

--- a/docs/04-使用手册.md
+++ b/docs/04-使用手册.md
@@ -408,6 +408,7 @@ claude plugin install videonote@videonote
 | 小红书扫码报 HTTP 406 | 旧版直连接口已被拒。升级后扫码改走本机 Chrome 打开官网。请安装 Google Chrome 后重试，或 `--cookie` 粘贴 |
 | 抖音下载失败 / 登录墙 | 让用户 `! videonote login douyin` 后重试（需本机 Chrome/Edge；没有就 `--cookie`）。`inspect_video` 应返回 `platform:"douyin"` |
 | 抖音扫码报「生成二维码失败: HTTP 200」/ 风控页 | 直连接口已被风控。升级后扫码改走本机 Chrome 打开官网。请安装 Google Chrome 后重试，或 `--cookie` 粘贴 |
+| 抖音扫码后手机已确认，CLI 一直「已扫码」 | 旧版只拦 HTTP 轮询；升级后会主动短轮询 check_qrconnect。仍不行用 `--cookie` |
 | `process_media`（diarize）报需安装/缺 token | pyannote 可选重依赖：`transcriber diarization on` 引导安装 + 配 HF_TOKEN + 同意模型授权 |
 | 任务长时间卡住 | `task` 看 message；可能视频很长或模型下载中，耐心等待或换小模型 |
 | 中文乱码/内容差 | 检查所选模型能力；`style` 会影响输出格式 |

--- a/docs/06-执行进度.md
+++ b/docs/06-执行进度.md
@@ -450,4 +450,4 @@
 
 ## 抖音扫码确认后 CLI 卡住（2026-09-10）
 
-- [x] 官网 `is_frontier` 时「已确认」可能只走 WebSocket，HTTP 一直 `scanned`。改为用本机 Chrome 上下文主动短轮询 `check_qrconnect`（关掉 is_frontier），状态不回退；WS JSON 也收。**1024 passed + ruff F/I-clean**。
+- [x] 官网 `is_frontier` 时「已确认」可能只走 WebSocket，HTTP 一直 `scanned`。改为用本机 Chrome 上下文主动短轮询 `check_qrconnect`（关掉 is_frontier），状态不回退；WS JSON 也收。（commit `155a4d6`）：**1024 passed + ruff F/I-clean**。

--- a/docs/06-执行进度.md
+++ b/docs/06-执行进度.md
@@ -447,3 +447,7 @@
 ## 抖音扫码改本机 Chrome（2026-09-10）
 
 - [x] 直连 SSO get_qrcode 被风控成 HTML（HTTP 200），改本机 Chrome 打开官网登录页拦截出码（Playwright `channel=chrome`）；`--cookie` 仍可用。二维码域放行 `amemv.com`。（commit `7ca3bba`）：**1019 passed + ruff F/I-clean**。
+
+## 抖音扫码确认后 CLI 卡住（2026-09-10）
+
+- [x] 官网 `is_frontier` 时「已确认」可能只走 WebSocket，HTTP 一直 `scanned`。改为用本机 Chrome 上下文主动短轮询 `check_qrconnect`（关掉 is_frontier），状态不回退；WS JSON 也收。**1024 passed + ruff F/I-clean**。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -900,7 +900,7 @@ v0.1.1 → v0.1.2 的主要变更（详见下方各「维护」节点块；稳�
 - Skill / 04 / troubleshooting / VENDOR 同步；改 Skill 后需刷新插件。
 - **验证**：全量 `pytest` **1019 passed, 1 skipped, 10 subtests passed**；Ruff F/I、`git diff --check` 通过。
 
-## 抖音扫码确认后 CLI 卡住（2026-09-10 · 1019→1024 tests）
+## 抖音扫码确认后 CLI 卡住（2026-09-10 · v0.1.28，1019→1024 tests）
 
 - **原因**：官网 `get_qrcode` 带 `is_frontier` 时，「已扫码」仍走 HTTP，`confirmed` 可能只推 WebSocket；CLI 只拦 HTTP，就会一直停在「已扫码，请在手机上确认登录」。
 - **修复**：用本机 Chrome 上下文主动短轮询 `check_qrconnect`（`is_frontier=0`），并收官方域 WebSocket JSON；扫码状态只前进不回退。passport 的 `4`/`refused` 视为过期（有 `redirect_url` 仍算成功）。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -899,3 +899,9 @@ v0.1.1 → v0.1.2 的主要变更（详见下方各「维护」节点块；稳�
 - **修复**：`videonote login douyin` 默认用本机 Chrome/Edge 打开官网登录页，拦截 `passport/web/get_qrcode` + `check_qrconnect`（与小红书同款 Playwright）；终端仍出 ASCII 码。无浏览器时回退直连接口并提示 `--cookie`。二维码 URL 额外放行官方扫码页 `amemv.com` / `iesdouyin.com`；passport 状态 `new/scanned/confirmed/expired` 与旧数字码并存。
 - Skill / 04 / troubleshooting / VENDOR 同步；改 Skill 后需刷新插件。
 - **验证**：全量 `pytest` **1019 passed, 1 skipped, 10 subtests passed**；Ruff F/I、`git diff --check` 通过。
+
+## 抖音扫码确认后 CLI 卡住（2026-09-10 · 1019→1024 tests）
+
+- **原因**：官网 `get_qrcode` 带 `is_frontier` 时，「已扫码」仍走 HTTP，`confirmed` 可能只推 WebSocket；CLI 只拦 HTTP，就会一直停在「已扫码，请在手机上确认登录」。
+- **修复**：用本机 Chrome 上下文主动短轮询 `check_qrconnect`（`is_frontier=0`），并收官方域 WebSocket JSON；扫码状态只前进不回退。passport 的 `4`/`refused` 视为过期（有 `redirect_url` 仍算成功）。
+- **验证**：全量 `pytest` **1024 passed, 1 skipped, 10 subtests passed**；Ruff F/I 通过。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videonote"
-version = "0.1.27"
+version = "0.1.28"
 description = "VideoNote 能力 MCP 封装：视频链接 → AI Markdown 笔记（内嵌下载/转写/LLM 流水线，无需启动 FastAPI 后端）"
 readme = "README.md"
 # 上界 3.14：faster-whisper(ctranslate2) 等目前尚未提供 3.14 wheel

--- a/skills/videonote/reference/troubleshooting.md
+++ b/skills/videonote/reference/troubleshooting.md
@@ -19,6 +19,7 @@
 | 小红书扫码报 406 | 旧版直连接口签名已失效。请用户升级 videonote 后重试扫码（走本机 Chrome）；或 `! videonote login xiaohongshu --cookie` |
 | 抖音下载失败 / 登录墙 | 引导用户 `! videonote login douyin`（终端扫码，需本机 Chrome/Edge，抖音 App 确认）；扫不了再用 `--cookie`。`inspect_video` 应返回 `platform:"douyin"` |
 | 抖音扫码报「HTTP 200」/ 风控页 | 直连接口已被拦截。请用户升级 videonote 后重试扫码（走本机 Chrome）；或 `! videonote login douyin --cookie` |
+| 抖音扫码后手机已确认，CLI 一直「已扫码」 | 旧版只拦 HTTP，frontier 下确认走 WebSocket。请升级后重试；仍不行再用 `--cookie` |
 | 整合评论/弹幕时评论拿不到 | 未配 B 站 SESSDATA —— 引导用户 `videonote login bilibili`；抓取失败**不阻断**笔记生成（跳过该部分） |
 | 其他平台（非内置平台） | `inspect_video` 返回 `platform:"generic"` → 自动走 **yt-dlp 通用提取**（覆盖 1800+ 站点）；若也失败任务报错 → Agent 接手：WebFetch/浏览器解析视频源后 `generate_note(video_url="/绝对/路径/x.mp4", platform="local")` |
 | generic 下载报需登录/JS 渲染 | 该站点 yt-dlp 无法直接提取 —— Agent 用 WebFetch/浏览器处理登录/验证，或让用户 `videonote setup` 向导里配「平台 Cookie」后重试 |

--- a/tests/test_douyin_auth.py
+++ b/tests/test_douyin_auth.py
@@ -139,6 +139,8 @@ class UrlAndCookieHelpersTest(unittest.TestCase):
         self.assertEqual(_map_qr_status({"redirect_url": "https://www.douyin.com/"}), QR_SUCCESS)
         self.assertEqual(_map_qr_status({"status": "5"}), QR_EXPIRED)
         self.assertEqual(_map_qr_status({"status": "expired"}), QR_EXPIRED)
+        self.assertEqual(_map_qr_status({"status": "4"}), QR_EXPIRED)
+        self.assertEqual(_map_qr_status({"status": "refused"}), QR_EXPIRED)
 
 
 class DouyinAuthQrTest(unittest.TestCase):
@@ -430,6 +432,70 @@ class DouyinBrowserQrParseTest(unittest.TestCase):
         qr._on_response(fake)
         self.assertEqual(qr._status, QR_SUCCESS)
         self.assertEqual(qr._redirect, "https://www.douyin.com/")
+
+    def test_on_response_does_not_downgrade_scanned_to_new(self):
+        from app.downloaders.douyin_browser import DouyinBrowserQr
+
+        qr = DouyinBrowserQr(cookie_mgr=mock.Mock())
+        fake = mock.Mock()
+        fake.url = "https://www.douyin.com/passport/web/check_qrconnect/?token=t"
+        fake.json.return_value = {"data": {"status": "scanned"}}
+        qr._on_response(fake)
+        fake.json.return_value = {"data": {"status": "new"}}
+        qr._on_response(fake)
+        self.assertEqual(qr._status, QR_SCANNED)
+
+    def test_rewrite_qrconnect_url_disables_frontier(self):
+        from app.downloaders.douyin_browser import rewrite_qrconnect_url
+
+        url = rewrite_qrconnect_url(
+            "https://login.douyin.com/passport/web/get_qrcode/?aid=6383&is_frontier=1",
+            "tok-1",
+        )
+        self.assertIn("/check_qrconnect", url)
+        self.assertIn("token=tok-1", url)
+        self.assertIn("is_frontier=0", url)
+        self.assertTrue(url.startswith("https://login.douyin.com/"))
+
+    def test_rewrite_qrconnect_url_rejects_foreign_host(self):
+        from app.downloaders.douyin_browser import rewrite_qrconnect_url
+
+        self.assertEqual(
+            rewrite_qrconnect_url("https://evil.example/passport/web/get_qrcode/", "tok"),
+            "",
+        )
+
+    def test_poll_qr_actively_fetches_confirmed(self):
+        from app.downloaders.douyin_browser import DouyinBrowserQr
+
+        qr = DouyinBrowserQr(cookie_mgr=mock.Mock())
+        qr._status = QR_SCANNED
+        qr._source_url = "https://www.douyin.com/passport/web/check_qrconnect/?token=old&is_frontier=1"
+        resp = mock.Mock()
+        resp.json.return_value = {
+            "data": {
+                "status": "confirmed",
+                "redirect_url": "https://www.douyin.com/?ticket=1",
+            }
+        }
+        qr._page = mock.Mock()
+        qr._page.request.get.return_value = resp
+        qr._cookies = lambda: {}
+        poll = qr.poll_qr("tok")
+        self.assertEqual(poll["status"], QR_SUCCESS)
+        self.assertIn("www.douyin.com", poll["redirect_url"])
+        called_url = qr._page.request.get.call_args.args[0]
+        self.assertIn("check_qrconnect", called_url)
+        self.assertIn("is_frontier=0", called_url)
+        self.assertIn("token=tok", called_url)
+
+    def test_ws_payload_confirmed_is_success(self):
+        from app.downloaders.douyin_browser import DouyinBrowserQr
+
+        qr = DouyinBrowserQr(cookie_mgr=mock.Mock())
+        qr._status = QR_SCANNED
+        qr._on_ws_payload('{"data":{"status":"confirmed","redirect_url":"https://www.douyin.com/"}}')
+        self.assertEqual(qr._status, QR_SUCCESS)
 
     def test_poll_sessionid_is_success(self):
         from app.downloaders.douyin_browser import DouyinBrowserQr

--- a/uv.lock
+++ b/uv.lock
@@ -4058,7 +4058,7 @@ wheels = [
 
 [[package]]
 name = "videonote"
-version = "0.1.27"
+version = "0.1.28"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },

--- a/videonote_mcp/__init__.py
+++ b/videonote_mcp/__init__.py
@@ -3,4 +3,4 @@
 入口：videonote_mcp.server:main（console script `videonote`）。
 """
 
-__version__ = "0.1.27"
+__version__ = "0.1.28"


### PR DESCRIPTION
## Summary
- 修复 `videonote login douyin` 扫码后手机已确认、CLI 一直停在「已扫码，请在手机上确认登录」：官网 `is_frontier` 时 `confirmed` 可能只走 WebSocket，HTTP 会一直返回 `scanned`。改为用本机 Chrome 上下文主动短轮询 `check_qrconnect`（关掉 `is_frontier`），并收官方域 WebSocket JSON；扫码状态只前进不回退。
- 测试基线 1019 → **1024 passed, 1 skipped, 10 subtests**；Ruff F/I 干净。
- 四处版本对齐到 **0.1.28**（`pyproject.toml` / `__init__.py` / `plugin.json` / `uv.lock`）。合并后打 **新标签** `v0.1.28`，触发 `release.yml` → GitHub Release + PyPI Trusted Publishing。
- Skill 排查说明有变更：合并后需 `claude plugin disable videonote@videonote` 再 `install`。MCP 走 `uvx videonote@latest` 会在发版后自动取 0.1.28。PATH 里 `uv tool install` 的 CLI 需再跑一次 `uv tool upgrade videonote`。

## Test plan
- [x] 本机全量 `1024 passed, 1 skipped, 10 subtests` + ruff F/I-clean
- [x] 四处版本字符串均为 `0.1.28`
- [ ] CI Smoke test 绿（Python 3.11/3.12/3.13）
- [ ] 合并后打 `v0.1.28` tag，确认 release.yml：四处版本一致 + 测试门禁 + wheel 内容 + MCP handshake + PyPI 发布
- [ ] 发布后 `uvx videonote@0.1.28` 能启动
- [ ] 合并后 `origin/dev` **快进**到 `origin/main`（不要再开同步 merge commit）


Made with [Cursor](https://cursor.com)