### PR TITLE
docs: 将代码导航移至贡献指南

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,14 @@ CLI 的 `setup` / `login` 可能写入真实配置，请在本机终端按需运
 - 历史第三方模板按 `videonote_mcp/templates/provenance.json` 校验原字节；`.gitattributes` 仅对恢复的原件关闭换行转换/空白检查，并将 PDF 标为二进制。不要格式化原件，新指南和代码仍走正常检查。
 - 分发相关改动还需 `uv build --no-sources`，检查 wheel/sdist 不包含 Skills/commands，但须含 `videonote_mcp/templates/` 及原许可证。执行 `uv run python tests/mcp_stdio_smoke.py --wheel dist/videonote-<版本>.whl`，从解包 wheel 在无关工作目录启动独立 stdio 冒烟，不可误用源码资源。
 
+## 维护与代码导航
+
+- **入口**：`videonote_mcp/server.py` 管 MCP 协议、权限与任务生命周期；`cli.py` 管终端初始化、登录和配置。密钥只在终端或官方页面填写。
+- **共享逻辑**：`videonote_mcp/task_artifacts.py` 统一读取任务状态和转写；`app/utils/local_paths.py` 统一路径规整与授权；`app/utils/media_source.py` 统一平台识别。`inspect.py` 的元信息预检和 `export/` 的确定性导出不依赖 MCP 入口、数据库或转写引擎初始化。
+- **处理流水线**：`app/services/note.py` 编排任务，`pipeline.py` 提供处理步骤；模板资源与渲染代码独立，第三方来源见 [VENDOR.md](VENDOR.md)。
+- **导出一致性**：CLI/MCP 优先读 `gen/transcript.json`，缓存缺失或损坏才退到 `result.json`；不改写原转写。已知失败或运行中的任务不能导出；无可读状态的旧任务仍允许恢复导出，但不表示任务已成功。CLI 显式 `--out-dir` 可选任意目录，MCP 仍默认限制在数据目录内。
+- **文档入口**：[接手指南](docs/00-新手上路.md)说明首次接手和验证基线，[架构设计](docs/02-架构设计.md)说明模块边界，[VENDOR.md](VENDOR.md)记录上游来源与分叉，[docs/04-使用手册.md](docs/04-使用手册.md)记录面向用户的安装与使用方式。
+
 ## 模块改动准则
 
 贡献流程完全记录在仓库中，不需要个人记忆或私有开发 Skill。先读 `docs/00-新手上路.md`、架构文档，编辑 `app/` 前核对 `VENDOR.md`。

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ---
 
-VideoNote-Mcp 把「视频链接 → 多格式笔记」整条流水线打包成 **MCP Server**：给 agent 一个链接，自动完成 下载 → 语音转写 → 画面理解 → 弹幕/评论，**默认由当前对话里的 Agent 写笔记**（配置 LLM 仅当 Agent 无法看图时作为后备）。
+VideoNote-Mcp 把「视频链接 → 多格式笔记」整条流水线打包成 **MCP Server**：给它一个链接，自动完成下载 → 语音转写 → 画面理解 → 弹幕/评论，并生成文字稿或笔记。
 
 仓库：[HuangYincan/VideoNote-MCP](https://github.com/HuangYincan/VideoNote-MCP)。
 
@@ -32,16 +32,16 @@ VideoNote-Mcp 把「视频链接 → 多格式笔记」整条流水线打包成 
 
 ## 快速开始
 
-**只配置 MCP 即可，不需要安装 Skills。**
+**配置 MCP 服务即可开始使用。**
 
 ```bash
 # 1) 注册独立 MCP（PyPI 已发布版本）
 claude mcp add --scope user videonote -- uvx videonote@latest
 
-# 2) 在终端配置转写 / 平台登录；默认由当前 Agent 写笔记，无需 LLM Key
+# 2) 在终端配置转写 / 平台登录；默认笔记流程无需 LLM Key
 uvx videonote@latest setup
 
-# 3) 重启或重连 MCP，然后发视频链接，请 Agent 输出文字稿或笔记
+# 3) 重启或重连 MCP，然后发送视频链接
 ```
 
 支持 JSON 的 MCP 客户端也可使用：
@@ -58,64 +58,19 @@ uvx videonote@latest setup
 }
 ```
 
-> 旧版 Skills 与 `/videonote-setup` 已移除，可通过 Git 历史查阅；LaTeX/Typst 模板已独立恢复到 `videonote_mcp/templates/`，不需要恢复 Skills。已经安装的旧插件或本地 Skill 不会自动删除；若改用独立 MCP，请手动停用旧插件/Skill，避免重复加载。源码修改需客户端直接指向源码，`uvx` 不会加载未发布的本地修复。
+> 如果之前配置过旧版插件，请先停用旧配置，再连接独立 MCP，避免同一个服务重复加载。
 
 > [!TIP]
 > 四种安装方式、配置细节、更新与安全见 [docs/04-使用手册.md](docs/04-使用手册.md)。
 
-### 使用源码中的修复（未发布到 PyPI）
+## 导出格式
 
-`uvx videonote@latest` 运行已发布的包，不会读取本地修改。需要本仓库的抖音修复时，使用 [源码 JSON 配置](examples/mcp.source.example.json)，将 `/absolute/path/to/VideoNote-MCP` 替换为实际仓库绝对路径：
+- **字幕**：支持 SRT、VTT 和 JSON，适合保存时间轴或导入其他工具。
+- **Markdown 笔记**：可根据转写、画面和评论整理成便于阅读和继续编辑的笔记。
+- **LaTeX / Typst**：安装包附带 Math Note、English Article 和 zju-lab 等模板，可在 MCP 客户端中列出、读取或复制到新目录。
+- 模板复制不会覆盖已有目录。LaTeX / Typst 的编译器、字体和依赖需要在本机准备；MCP 负责提供素材与模板，不自动编译 PDF。
 
-```json
-{
-  "mcpServers": {
-    "videonote": {
-      "type": "stdio",
-      "command": "uv",
-      "args": [
-        "--directory",
-        "/absolute/path/to/VideoNote-MCP",
-        "run",
-        "--frozen",
-        "videonote"
-      ]
-    }
-  }
-}
-```
-
-在终端使用同一份源码登录，然后重连 MCP：
-
-```bash
-uv --directory /absolute/path/to/VideoNote-MCP sync --frozen
-uv --directory /absolute/path/to/VideoNote-MCP run --frozen videonote login douyin
-```
-
-若设置了 `VIDEONOTE_DATA_DIR` / `VIDEONOTE_CONFIG_DIR`，CLI 与 MCP 必须使用相同值。手机确认后如有二次验证，请在打开的官方浏览器窗口内完成；附加校验未能确认不等于 Cookie 无效，不必仅因此反复扫码。详见[抖音登录排障](docs/04-使用手册.md#抖音登录扫码)。
-
-## Agent 指引与独立导出模板
-
-MCP 初始化说明与 `health_check` / `get_config` 会提供官方仓库、安装/排障文档入口及版本匹配提醒；失败体检项返回 `next_steps`。这些是建议，不会自动安装依赖或修改配置。MCP 尚未启动时，先按本 README 配置，再结合客户端启动日志排查。
-
-**无需 Skills，也保留排版模板**：Math Note（LaTeX 中英文）、English Article（LaTeX）、zju-lab（Typst）随安装包分发，含原始许可证与配套文件。仍为 **10 个工具**，不需要改 MCP JSON。
-
-```text
-process_media(action="template")                                          # 列模板
-process_media(action="template", template_file="GUIDE.md")                 # 离线导出指南
-process_media(action="template", template_id="latex-math-note",
-              template_file="main.tex")                                  # 读源码
-process_media(action="template", template_id="latex-math-note",
-              out_dir="<health_check.data_dir>/exports/my-note")           # 复制到新的目录
-```
-
-已有目录不覆盖；默认仅写数据目录内。也可读取 `videonote://templates` / `videonote://help/export` Resources，不支持 Resources 的客户端走以上工具即可。
-
-- SRT/VTT/JSON：`process_media(action="export")` 确定性导出。
-- LaTeX/Typst：Agent 复用已有底稿填模板；**MCP 不自动编译 PDF**。有编译器、字体及依赖且实际编译成功后才交付 PDF，否则交付完整源码。历史样例 PDF 不是用户生成的结果。
-- 详见[随包导出指南](videonote_mcp/templates/README.md)。凭证只在用户终端或官方页面输入。
-
-> 以上描述当前源码能力。已发布包可能尚未包含这些修改：先核对 `health_check.server_version` 与发布记录；需要当前代码时使用上面的源码配置，不把 `main/dev` 文档当作旧版本的功能保证。
+完整的导出说明见[使用手册](docs/04-使用手册.md)。
 
 ## 文档
 
@@ -130,19 +85,19 @@ process_media(action="template", template_id="latex-math-note",
 
 ## 真实案例
 
-两个端到端真实案例：一个走 **AGENT 直接生成**并输出 LaTeX mathnote PDF，一个走 **全自动 LLM 生成**产出便携 Markdown。
+两个端到端真实案例：一个由对话助手直接生成 LaTeX mathnote PDF，一个走 **全自动 LLM 生成**产出便携 Markdown。
 
 ### 案例一 · agent_direct + LaTeX mathnote（DeepSeek-V4 视频）
 
 > 来源：[【闪客】深入解读 DeepSeek V1~V4！男女老少都听得懂～](https://www.bilibili.com/video/BV1rpovBCEGH/?vd_source=2a93b97e35c51587de18c73fcf753191)
 
-一条视频 + 四类外部资料（论文 / 技术报告 / 公众号官宣 / 开源集合）→ **AGENT 直接生成**精修笔记，并输出 **LaTeX mathnote PDF**（中文楷体模板）：
+一条视频 + 四类外部资料（论文 / 技术报告 / 公众号官宣 / 开源集合）→ **对话助手直接生成**精修笔记，并输出 **LaTeX mathnote PDF**（中文楷体模板）：
 
 | Page1 | Page2 | Page3 |
 | :---: | :---: | :---: |
 | <img width="250" src="examples/agent-direct-deepseek-v4-mathnote/deepseek-v4-mathnote-page1.jpg"> | <img width="250" src="examples/agent-direct-deepseek-v4-mathnote/deepseek-v4-mathnote-page2.jpg"> | <img width="250" src="examples/agent-direct-deepseek-v4-mathnote/deepseek-v4-mathnote-page3.jpg"> |
 
-- 无 LLM key：Agent 读转写 + 帧图 + 评论自写笔记
+- 无 LLM key：根据转写、帧图和评论整理笔记
 - 多源交叉整合：视频 × 论文 × 技术报告 × 开源清单
 - 精修保留原稿：`note.md` / `note_original.md` 双份
 - LaTeX mathnote PDF：自适应修复字体缺失 / 断行溢出 / 引用去重
@@ -165,7 +120,7 @@ process_media(action="template", template_id="latex-math-note",
 
 <img src="assets/pipeline.svg" alt="VideoNote-Mcp 流水线地图" width="100%"/>
 
-实线为主流程：一条 `prepare_note_material` 出素材，由当前对话 Agent 写笔记；`generate_note` 是后备（Agent 无法看图时走配置 LLM）。虚线为可选能力（视频理解 / 弹幕评论）。各阶段细节见 [docs/02-架构设计.md](docs/02-架构设计.md)。
+实线为主流程：一条 `prepare_note_material` 出素材，由当前对话助手整理笔记；`generate_note` 是后备（对话助手无法看图时走配置 LLM）。虚线为可选能力（视频理解 / 弹幕评论）。各阶段细节见 [docs/02-架构设计.md](docs/02-架构设计.md)。
 
 ## 任务管理
 
@@ -201,24 +156,14 @@ flowchart TB
 
 - **学习备考**：端到端 + 视频理解 + 基于字幕的后续优化，把课程讲透。
 - **会议纪要**：`process_media(action="merge")` 合并分段录音 → `process_media(action="diarize")` 说话人分离 → `meeting_minutes` 风格。
-- **讲座精读**：端到端生成后，agent 基于完整字幕精修、按章节补齐细节。
+- **讲座精读**：端到端生成后，根据完整字幕精修、按章节补齐细节。
 - **视频赏析**：开启弹幕 + 评论整合，笔记含「观众观点」章节。
-- **默认路径**：一条链接用 `prepare_note_material`，由当前对话 Agent 写笔记；Agent 无法看图或用户要求配置 LLM 时才用 `generate_note`。只做媒体加工用 `process_media`。
+- **默认路径**：一条链接用 `prepare_note_material`，由当前对话助手整理笔记；无法看图或用户要求配置 LLM 时才用 `generate_note`。只做媒体加工用 `process_media`。
 - **真实案例**：完整案例过程记录见 [`examples`](examples)。
-
-## 维护与代码导航
-
-- **入口**：`videonote_mcp/server.py` 管 MCP 协议、权限与任务生命周期；`cli.py` 管终端初始化、登录和配置。密钥只在终端/官方页面填写。
-- **共享逻辑**：`task_artifacts.py` 统一读取任务状态和转写；`app/utils/local_paths.py` 统一路径规整/授权；`app/utils/media_source.py` 统一平台识别。`inspect.py` 的元信息预检和 `export/` 的确定性导出不依赖 MCP 入口、数据库或转写引擎初始化。
-- **处理流水线**：`app/services/note.py` 编排任务，`pipeline.py` 提供处理步骤；模板资源与渲染代码独立，第三方来源见 [VENDOR.md](VENDOR.md)。
-- **导出一致性**：CLI/MCP 优先读 `gen/transcript.json`，缓存缺失/损坏才退到 `result.json`；不改写原转写。已知失败/运行中任务不能导出；无可读状态的旧任务仍允许恢复导出，但不表示任务已成功。CLI 显式 `--out-dir` 可选任意目录，MCP 仍默认限制在数据目录内。
-
-开发者从[接手指南](docs/00-新手上路.md)和[架构设计](docs/02-架构设计.md)开始；不需要本机私有 Skill 或个人记忆。测试隔离运行数据，协议冒烟同时检查源码和 wheel，模板原件按哈希校验。具体命令见 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
 ## 如何贡献
 
-- 长期分支仅保留 `dev`、`main`。临时功能分支 → PR → `dev`（CI 必须绿）→ PR → `main`；交付后将 `dev` 快进到 `main`，删除已合入的临时分支，保持两者最新。
-- 流程、分支命名与提交前自查见 [CONTRIBUTING.md](CONTRIBUTING.md)。
+欢迎提交 Issue、改进建议和 Pull Request。开发环境、测试命令、分支策略与代码导航见 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
 ## 致谢
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -14,7 +14,7 @@
 
 ---
 
-VideoNote-Mcp packages the whole "video link → multi-format notes" pipeline into an **MCP Server**: hand an agent a link and it automatically runs download → transcription → frame understanding → danmaku/comments. **By default the current conversation agent writes the note**; the configured LLM is only a fallback when the agent cannot see images.
+VideoNote-Mcp packages the whole "video link → multi-format notes" pipeline into an **MCP Server**: give it a link and it automatically runs download → transcription → frame understanding → danmaku/comments, then produces a transcript or note.
 
 Repository: [HuangYincan/VideoNote-MCP](https://github.com/HuangYincan/VideoNote-MCP).
 
@@ -32,17 +32,17 @@ It works **end-to-end (one link → one note)** and is **also decoupled**: pick 
 
 ## Quick Start
 
-**Configure the MCP server directly; no Skills required.**
+**Configure the MCP server directly to get started.**
 
 ```bash
 # 1) Register the standalone MCP server (published PyPI version)
 claude mcp add --scope user videonote -- uvx videonote@latest
 
 # 2) Configure transcription / platform login in your terminal
-#    The default agent-written note workflow needs no LLM API key
+#    The default note workflow needs no LLM API key
 uvx videonote@latest setup
 
-# 3) Restart or reconnect MCP, then give your agent a video link
+# 3) Restart or reconnect MCP, then send a video link
 ```
 
 For JSON-based MCP clients:
@@ -59,63 +59,18 @@ For JSON-based MCP clients:
 }
 ```
 
-> Legacy Skills and `/videonote-setup` have been removed and remain available in Git history. LaTeX/Typst templates have been restored independently under `videonote_mcp/templates/`; restoring Skills is not required. Previously installed plugins or local Skills are not automatically removed; disable the old integration when switching to standalone MCP to avoid duplicate loading. Point your client at a source checkout to test unpublished fixes: `uvx` does not load local changes.
+> If you previously configured the legacy plugin, disable the old configuration before connecting the standalone MCP server to avoid loading the same service twice.
 
 > All four install methods, configuration details, updating and security are in [docs/04-使用手册.md](docs/04-使用手册.md).
 
-### Run fixes from a source checkout (not yet on PyPI)
+## Export Formats
 
-`uvx videonote@latest` runs a published package, not local changes. To use the Douyin fixes in this repository, use the [source JSON configuration](examples/mcp.source.example.json) and replace `/absolute/path/to/VideoNote-MCP` with the checkout's absolute path:
+- **Subtitles:** SRT, VTT and JSON for preserving timestamps or importing into other tools.
+- **Markdown notes:** organize the transcript, frames and comments into notes that are easy to read and edit.
+- **LaTeX / Typst:** the package includes Math Note, English Article and zju-lab templates. An MCP client can list, read and copy them to a new directory.
+- Template copies never overwrite an existing directory. Install the required LaTeX / Typst compiler, fonts and packages locally; MCP provides the materials and templates but does not compile PDFs automatically.
 
-```json
-{
-  "mcpServers": {
-    "videonote": {
-      "type": "stdio",
-      "command": "uv",
-      "args": [
-        "--directory",
-        "/absolute/path/to/VideoNote-MCP",
-        "run",
-        "--frozen",
-        "videonote"
-      ]
-    }
-  }
-}
-```
-
-Log in with the same checkout, then reconnect the MCP server:
-
-```bash
-uv --directory /absolute/path/to/VideoNote-MCP sync --frozen
-uv --directory /absolute/path/to/VideoNote-MCP run --frozen videonote login douyin
-```
-
-If you set `VIDEONOTE_DATA_DIR` / `VIDEONOTE_CONFIG_DIR`, use identical values for the CLI and MCP server. Complete any secondary verification in the official browser window. An inconclusive follow-up check does not mean the saved Cookie is invalid; it alone is not a reason to scan again. See [Douyin troubleshooting (Chinese)](docs/04-使用手册.md#抖音登录扫码).
-
-## Agent guidance and standalone export templates
-
-Initialization instructions and `health_check` / `get_config` expose the official repository, installation/troubleshooting docs, and version-matching advice. Failed health checks include `next_steps`; they do not install dependencies or change configuration. If the MCP server cannot start, use this README and the client's startup logs first.
-
-**No Skills required; templates are included:** Math Note (English/Chinese LaTeX), English Article (LaTeX), and zju-lab (Typst), with their original licenses and companion files. There are still **10 tools**, and your MCP JSON does not need to change.
-
-```text
-process_media(action="template")                                          # list templates
-process_media(action="template", template_file="GUIDE.md")                 # offline guide
-process_media(action="template", template_id="latex-math-note",
-              template_file="main.tex")                                  # read source
-process_media(action="template", template_id="latex-math-note",
-              out_dir="<health_check.data_dir>/exports/my-note")           # copy to a NEW directory
-```
-
-Existing directories are never overwritten; writes are restricted to the data directory by default. Resources `videonote://templates` and `videonote://help/export` are also available, with the tool calls above as a fallback for clients without resource support.
-
-- SRT/VTT/JSON: deterministic export with `process_media(action="export")`.
-- LaTeX/Typst: the agent adapts the template using the existing note/transcript. **MCP does not automatically compile PDF.** Deliver a PDF only after successful compilation with the required compiler, fonts and packages; otherwise deliver complete source files. Bundled sample PDFs are not user-generated outputs.
-- See the [bundled export guide](videonote_mcp/templates/README.md). Credentials stay in the user's terminal or the platform's official page.
-
-> This describes the current source tree. Published packages may not include these changes yet: check `health_check.server_version` against release notes. Use the source configuration above for this implementation; do not assume `main/dev` docs apply to an older release.
+See the [user manual](docs/04-使用手册.md) for the complete export guide.
 
 ## Docs
 
@@ -131,19 +86,19 @@ Full installation / configuration / usage / env vars / updating / security docs 
 
 ## Real-world Examples
 
-Two end-to-end examples: one runs **AGENT direct generation** and outputs a **LaTeX mathnote PDF**; the other runs **fully automatic LLM generation** and produces portable Markdown.
+Two end-to-end examples: one uses direct conversation-assisted generation to produce a **LaTeX mathnote PDF**; the other runs **fully automatic LLM generation** and produces portable Markdown.
 
 ### Example 1 · agent_direct + LaTeX mathnote (DeepSeek-V4 video)
 
 > Source: [【闪客】深入解读 DeepSeek V1~V4！男女老少都听得懂～](https://www.bilibili.com/video/BV1rpovBCEGH/?vd_source=2a93b97e35c51587de18c73fcf753191)
 
-One video + four kinds of external sources (paper / tech report / WeChat announcement / open-source collections) → **AGENT direct generation** of a refined note, output as a **LaTeX mathnote PDF** (Chinese KaiTi template):
+One video + four kinds of external sources (paper / tech report / WeChat announcement / open-source collections) → **conversation-assisted generation** of a refined note, output as a **LaTeX mathnote PDF** (Chinese KaiTi template):
 
 | Page1 | Page2 | Page3 |
 | :---: | :---: | :---: |
 | <img width="250" src="examples/agent-direct-deepseek-v4-mathnote/deepseek-v4-mathnote-page1.jpg"> | <img width="250" src="examples/agent-direct-deepseek-v4-mathnote/deepseek-v4-mathnote-page2.jpg"> | <img width="250" src="examples/agent-direct-deepseek-v4-mathnote/deepseek-v4-mathnote-page3.jpg"> |
 
-- No LLM key: the Agent writes the note from transcript + frames + comments
+- No LLM key: the note is organized from the transcript, frames and comments
 - Multi-source cross-integration: video × paper × tech report × open-source list
 - Refined copy keeps the original: `note.md` / `note_original.md` pair
 - LaTeX mathnote PDF: auto-fixes missing fonts / line-overflow / citation dedup
@@ -166,7 +121,7 @@ Full run record: [`examples/note-generation-example/README.md`](examples/note-ge
 
 <img src="assets/pipeline-en.svg" alt="VideoNote-Mcp pipeline map" width="100%"/>
 
-Solid lines are the main flow: `prepare_note_material` produces the pack, and the current conversation agent writes the note. `generate_note` is the fallback (configured LLM when the agent cannot see images). Dashed lines are optional capabilities (video understanding / danmaku + comments). Stage details live in [docs/02-架构设计.md](docs/02-架构设计.md).
+Solid lines are the main flow: `prepare_note_material` produces the pack, and the conversation assistant organizes the note. `generate_note` is the fallback when image understanding requires the configured LLM. Dashed lines are optional capabilities (video understanding / danmaku + comments). Stage details live in [docs/02-架构设计.md](docs/02-架构设计.md).
 
 ## Task Management
 
@@ -202,24 +157,14 @@ flowchart TB
 
 - **Study & exam prep**: end-to-end + video understanding + transcript-based follow-up refinement.
 - **Meeting minutes**: `process_media(action="merge")` to join recorded segments → `process_media(action="diarize")` for speakers → `meeting_minutes` style.
-- **Deep-reading a lecture**: after end-to-end generation, the agent refines from the full transcript, filling in section by section.
+- **Deep-reading a lecture**: after end-to-end generation, refine from the full transcript, filling in section by section.
 - **Video appreciation**: enable danmaku + comment integration for an "Audience viewpoints" section.
-- **Default path**: one link uses `prepare_note_material`, and the current conversation agent writes the note; use `generate_note` only when the agent cannot see images or the user asks for the configured LLM. Use `process_media` for media operations (merge / diarize / export).
+- **Default path**: one link uses `prepare_note_material`, and the conversation assistant organizes the note; use `generate_note` when image understanding requires the configured LLM or the user asks for it. Use `process_media` for media operations (merge / diarize / export).
 - **Real example**: full run records for both cases live in [`examples`](examples).
-
-## Maintenance and code navigation
-
-- **Entry points:** `videonote_mcp/server.py` owns MCP transport, permissions and task lifecycle; `cli.py` owns terminal setup, login and configuration. Credentials stay in the terminal or official login page.
-- **Shared logic:** `task_artifacts.py` reads task status/transcripts; `app/utils/local_paths.py` normalizes paths and enforces access policy; `app/utils/media_source.py` detects platforms. Metadata inspection in `inspect.py` and deterministic `export/` do not require MCP, database or transcription-engine initialization.
-- **Processing pipeline:** `app/services/note.py` orchestrates tasks and `pipeline.py` provides processing steps. Template resources stay separate from rendering code; see [VENDOR.md](VENDOR.md) for third-party provenance.
-- **Consistent exports:** CLI/MCP prefer `gen/transcript.json`, falling back to `result.json` when the cache is missing or unusable, without overwriting the original transcript. Known failed/running tasks cannot be exported. Legacy tasks with unreadable/missing status can still be recovered by export, but this does not mark them successful. Explicit CLI `--out-dir` allows arbitrary destinations; MCP remains data-directory-restricted by default.
-
-Start with the [handoff guide](docs/00-新手上路.md) and [architecture](docs/02-架构设计.md). No private local Skill or personal memory is required. Tests isolate runtime data, protocol smoke tests cover both source and wheel, and original template bytes are hash-checked. Commands are in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## How to Contribute
 
-- Keep only `dev` and `main` as permanent branches. Temporary feature branch → PR → `dev` (CI must pass) → PR → `main`. After delivery, fast-forward `dev` to `main` and remove merged temporary branches so both remain current.
-- Workflow, branch naming and pre-commit self-checks are in [CONTRIBUTING.md](CONTRIBUTING.md).
+Issues, improvement ideas and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the development environment, tests, branch policy and code navigation.
 
 ## Acknowledgements
 

--- a/tests/test_mcp_only_distribution.py
+++ b/tests/test_mcp_only_distribution.py
@@ -170,17 +170,14 @@ def test_source_config_pins_checkout_without_personal_configuration():
     }
 
 
-def test_readme_json_matches_published_and_source_examples():
+def test_readme_json_matches_published_example():
     import re
 
-    configs = [
-        json.loads((REPO / name).read_text())
-        for name in ("examples/mcp.example.json", "examples/mcp.source.example.json")
-    ]
+    published_config = json.loads((REPO / "examples/mcp.example.json").read_text())
     for name in ("README.md", "README_EN.md"):
         blocks = re.findall(r"```json\n(.*?)\n```", (REPO / name).read_text(), re.DOTALL)
         parsed = [json.loads(block) for block in blocks]
-        assert all(config in parsed for config in configs), name
+        assert published_config in parsed, name
 
 
 def test_architecture_diagram_is_mcp_only_without_embedded_assets():

--- a/tests/test_repository_docs.py
+++ b/tests/test_repository_docs.py
@@ -27,11 +27,27 @@ def test_local_documentation_links_exist(filename):
         assert (document.parent / unquote(parsed.path)).exists(), (filename, target)
 
 
-@pytest.mark.parametrize("filename", ["README.md", "README_EN.md", "docs/02-架构设计.md"])
+@pytest.mark.parametrize("filename", ["CONTRIBUTING.md", "VENDOR.md", "docs/02-架构设计.md"])
 def test_shared_modules_are_discoverable_in_live_docs(filename):
     text = (ROOT / filename).read_text(encoding="utf-8")
     for module in ("task_artifacts.py", "local_paths.py", "media_source.py"):
         assert module in text
+
+
+@pytest.mark.parametrize("filename", ["README.md", "README_EN.md"])
+def test_readmes_remain_user_facing(filename):
+    text = (ROOT / filename).read_text(encoding="utf-8")
+    for internal_section in (
+        "维护与代码导航",
+        "Maintenance and code navigation",
+        "使用源码中的修复",
+        "Run fixes from a source checkout",
+        "Agent 指引与独立导出模板",
+        "Agent guidance and standalone export templates",
+    ):
+        assert internal_section not in text
+    for implementation_module in ("task_artifacts.py", "local_paths.py", "media_source.py"):
+        assert implementation_module not in text
 
 
 def test_contributor_guidance_does_not_require_private_skills():


### PR DESCRIPTION
将 README 面向普通用户整理，并把开发者维护信息集中到 CONTRIBUTING。

变更：
- 删除 README/README_EN 中的维护与代码导航章节
- 移除源码修复和 Agent 内部指引等开发者内容
- 保留面向用户的导出格式与 LaTeX/Typst 模板说明
- 将代码入口、模块边界和导出一致性说明移至 CONTRIBUTING.md
- 更新文档回归测试

验证：1265 passed, 1 skipped, 10 subtests passed；Ruff 与 git diff --check 通过。